### PR TITLE
Cleaned up Rectangle, Circle and rest of math files

### DIFF
--- a/include/sfz/math/Alignment.hpp
+++ b/include/sfz/math/Alignment.hpp
@@ -3,137 +3,145 @@
 #define SFZ_MATH_ALIGNMENT_HPP
 
 #include <string>
+#include <cassert>
 
 namespace sfz {
 
-	/**
-	 * @brief A simple enum used to determine if something is left, center or right-aligned horizontally.
-	 *
-	 * The different values are considered to have different distance from each other. The distance from LEFT to
-	 * CENTER is one unit, the distance from LEFT to RIGHT is two units. The formula for calculating the distance is
-	 * 'destination - origin'. Therefore going from LEFT to RIGHT is the positive direction, going from RIGHT to LEFT
-	 * is the negative direction.
-	 *
-	 * @author Peter Hillerström <peter@hstroem.se>
-	 */
-	enum class HorizontalAlign : char {
-		LEFT = -1, 
-		CENTER = 0, 
-		RIGHT = 1
-	};
+/**
+ * @brief An enum used to determine if something is left, center or right-aligned horizontally.
+ *
+ * The different values are considered to have different distance from each other. The distance
+ * from LEFT to CENTER is one unit, the distance from LEFT to RIGHT is two units. The formula for
+ * calculating the distance is 'destination - origin'. Therefore going from LEFT to RIGHT is the
+ * positive direction, going from RIGHT to LEFT is the negative direction.
+ *
+ * @author Peter Hillerström <peter@hstroem.se>
+ */
+enum class HorizontalAlign : char {
+	LEFT = -1, 
+	CENTER = 0, 
+	RIGHT = 1
+};
 
-	/**
-	 * @brief A simple enum used to determine if something is bottom, middle or top-aligned vertically.
-	 *
-	 * The different values are considered to have different distance from each other. The distance from BOTTOM to
-	 * MIDDLE is one unit, the distance from BOTTOM to TOP is two units. The formula for calculating the distance is
-	 * 'destination - origin'. Therefore going from BOTTOM to TOP is the positive direction, going from TOP to BOTTOM
-	 * is the negative direction.
-	 *
-	 * author Peter Hillerström <peter@hstroem.se>
-	 */
-	enum class VerticalAlign : char {
-		BOTTOM = -1, 
-		MIDDLE = 0, 
-		TOP = 1
-	};
+/**
+ * @brief An enum used to determine if something is bottom, middle or top-aligned vertically.
+ *
+ * The different values are considered to have different distance from each other. The distance
+ * from BOTTOM to MIDDLE is one unit, the distance from BOTTOM to TOP is two units. The formula for
+ * calculating the distance is 'destination - origin'. Therefore going from BOTTOM to TOP is the
+ * positive direction, going from TOP to BOTTOM is the negative direction.
+ *
+ * author Peter Hillerström <peter@hstroem.se>
+ */
+enum class VerticalAlign : char {
+	BOTTOM = -1, 
+	MIDDLE = 0, 
+	TOP = 1
+};
 
-	/**
-	 * @brief Returns a string representation of the enum.
-	 * @return string representation of the enum
-	 */
-	inline std::string to_string(HorizontalAlign align) {
-		switch(align) {
-		case HorizontalAlign::LEFT:
-			return std::move(std::string{"LEFT"});
-		case HorizontalAlign::CENTER:
-			return std::move(std::string{"CENTER"});
-		case HorizontalAlign::RIGHT:
-			return std::move(std::string{"RIGHT"});
-		}
+/**
+ * @brief Returns a string representation of the enum.
+ * @return string representation of the enum
+ */
+inline std::string to_string(HorizontalAlign align) noexcept
+{
+	switch (align) {
+	case HorizontalAlign::LEFT:
+		return std::move(std::string{"LEFT"});
+	case HorizontalAlign::CENTER:
+		return std::move(std::string{"CENTER"});
+	case HorizontalAlign::RIGHT:
+		return std::move(std::string{"RIGHT"});
 	}
+}
 
-	/**
-	 * @brief Returns a string representation of the enum.
-	 * @return string representation of the enum
-	 */
-	inline std::string to_string(VerticalAlign align) {
-		switch(align) {
-		case VerticalAlign::BOTTOM:
-			return std::move(std::string{"BOTTOM"});
-		case VerticalAlign::MIDDLE:
-			return std::move(std::string{"MIDDLE"});
-		case VerticalAlign::TOP:
-			return std::move(std::string{"TOP"});
-		}
+/**
+ * @brief Returns a string representation of the enum.
+ * @return string representation of the enum
+ */
+inline std::string to_string(VerticalAlign align) noexcept
+{
+	switch (align) {
+	case VerticalAlign::BOTTOM:
+		return std::move(std::string{"BOTTOM"});
+	case VerticalAlign::MIDDLE:
+		return std::move(std::string{"MIDDLE"});
+	case VerticalAlign::TOP:
+		return std::move(std::string{"TOP"});
 	}
+}
 
-	/**
-	 * @brief Calculates the distance between two HorizontalAlign enums.
-	 * 
-	 * Calculates and returns the distance between two enum values as defined by the enums. The answer will be signed
-	 * and may have a positive or negative value depending on the 'direction'. 
-	 *
-	 * @param origin the origin enum
-	 * @param destination the destination enum
-	 * @return the distance between the two enums
-	 */
-	inline char distance(HorizontalAlign origin, HorizontalAlign destination) {
-		return static_cast<char>(destination) - static_cast<char>(origin);
-	}
+/**
+ * @brief Calculates the distance between two HorizontalAlign enums.
+ * 
+ * Calculates and returns the distance between two enum values as defined by the enums. The answer
+ * will be signed and may have a positive or negative value depending on the 'direction'. 
+ *
+ * @param origin the origin enum
+ * @param destination the destination enum
+ * @return the distance between the two enums
+ */
+inline char distance(HorizontalAlign origin, HorizontalAlign destination) noexcept
+{
+	return static_cast<char>(destination) - static_cast<char>(origin);
+}
 
-	/**
-	 * @brief Calculates the distance between two VerticalAlign enums.
-	 * 
-	 * Calculates and returns the distance between two enum values as defined by the enums. The answer will be signed
-	 * and may have a positive or negative value depending on the 'direction'. 
-	 *
-	 * @param origin the origin enum
-	 * @param destination the destination enum
-	 * @return the distance between the two enums
-	 */
-	inline char distance(VerticalAlign origin, VerticalAlign destination) {
-		return static_cast<char>(destination) - static_cast<char>(origin);
-	}
+/**
+ * @brief Calculates the distance between two VerticalAlign enums.
+ * 
+ * Calculates and returns the distance between two enum values as defined by the enums. The answer
+ * will be signed and may have a positive or negative value depending on the 'direction'. 
+ *
+ * @param origin the origin enum
+ * @param destination the destination enum
+ * @return the distance between the two enums
+ */
+inline char distance(VerticalAlign origin, VerticalAlign destination) noexcept
+{
+	return static_cast<char>(destination) - static_cast<char>(origin);
+}
 
-	/**
-	 * @brief Calculates the new position when changing alignment.
-	 *
-	 * Beware that this function will probably cause problems in a coordinate system with inverted y-axis (i.e. (0,0)
-	 * in upper left corner).
-	 * 
-	 * @param oldPosition the old position
-	 * @param size the size of the object in the desired axis
-	 * @param oldAlignment the old alignment
-	 * @param newAlignment the new alignment
-	 * @return the new position
-	 */
-	template<typename T, typename Align>
-	T calculateNewPosition(T oldPosition, T size, Align oldAlignment, Align newAlignment) {
-		// Calculate the denominator. If the align distance is 2 we don't want to do anything to the size, i.e. divide
-		// by 1. If the distance is 1 we want to adjust by half the size, so we divide by 2. 
-		char denominator;
-		switch(distance(oldAlignment, newAlignment)) {
-		case 0:
-			// origin == destination, so do nothing.
-			return oldPosition;
-		case -2:
-			denominator = -1;
-			break;
-		case -1:
-			denominator = -2;
-			break;
-		case 1:
-			denominator = 2;
-			break;
-		case 2:
-			denominator = 1;
-			break;
-		default:
-			throw std::logic_error{"This should not be possible."};
-		}
-		// Adjust the position with the size of the object divided by the previously calculated denominator.
-		return oldPosition + (size / static_cast<T>(denominator));
+/**
+ * @brief Calculates the new position when changing alignment.
+ *
+ * Beware that this function will probably cause problems in a coordinate system with inverted
+ * y-axis (i.e. (0,0) in upper left corner).
+ * 
+ * @param oldPosition the old position
+ * @param size the size of the object in the desired axis
+ * @param oldAlignment the old alignment
+ * @param newAlignment the new alignment
+ * @return the new position
+ */
+template<typename T, typename Align>
+T calculateNewPosition(T oldPosition, T size, Align oldAlignment, Align newAlignment) noexcept
+{
+	// Calculate the denominator. If the align distance is 2 we don't want to do anything to the
+	// size, i.e. divide by 1. If the distance is 1 we want to adjust by half the size, so we 
+	// divide by 2. 
+	char denominator;
+	switch (distance(oldAlignment, newAlignment)) {
+	case 0:
+		// origin == destination, so do nothing.
+		return oldPosition;
+	case -2:
+		denominator = -1;
+		break;
+	case -1:
+		denominator = -2;
+		break;
+	case 1:
+		denominator = 2;
+		break;
+	case 2:
+		denominator = 1;
+		break;
+	default:
+		assert(false); // This should not be possible.
 	}
- }
+	// Adjust the position with object size divided by the previously calculated denominator.
+	return oldPosition + (size / static_cast<T>(denominator));
+}
+ 
+} // namespace sfz
 #endif

--- a/include/sfz/math/Alignment.hpp
+++ b/include/sfz/math/Alignment.hpp
@@ -52,6 +52,8 @@ inline std::string to_string(HorizontalAlign align) noexcept
 		return std::move(std::string{"CENTER"});
 	case HorizontalAlign::RIGHT:
 		return std::move(std::string{"RIGHT"});
+	default:
+		assert(false);
 	}
 }
 
@@ -68,6 +70,8 @@ inline std::string to_string(VerticalAlign align) noexcept
 		return std::move(std::string{"MIDDLE"});
 	case VerticalAlign::TOP:
 		return std::move(std::string{"TOP"});
+	default:
+		assert(false);
 	}
 }
 

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -2,7 +2,6 @@
 #ifndef SFZ_MATH_CIRCLE_HPP
 #define SFZ_MATH_CIRCLE_HPP
 
-#include <stdexcept> // std::invalid_argument
 #include <functional> // std::hash
 #include <string>
 #include "sfz/math/MathConstants.hpp"
@@ -16,6 +15,8 @@ namespace sfz {
 
 /**
  * @brief A class representing a Circle.
+ *
+ * All members are public and should be directly accessed, but there are a few convenience getters.
  *
  * The two alignment variables decide how the Circle is anchored to the position. Basically imagine
  * an invsible square around the circle, BOTTOM LEFT is the bottom left corner on that square, etc.
@@ -43,6 +44,14 @@ public:
 	 */
 	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
 
+	// Public Members
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	vec2<T> mPos;
+	T mRadius;
+	HorizontalAlign mHorizontalAlign;
+	VerticalAlign mVerticalAlign;
+
 	// Constructors and destructors
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
@@ -61,34 +70,32 @@ public:
 	 * @param circle the circle to copy
 	 */
 	template<typename T2>
-	explicit Circle(const Circle<T2>& circle);
+	explicit Circle(const Circle<T2>& circle) noexcept;
 
 	/**
 	 * @brief Copy constructor that changes alignment.
-	 * The alignment is changed as it would be if changeHorizontalAlign() or changeVerticalAlign()
-	 * were called.
+	 * The alignment is changed as it would be if changeAlign() were called.
+	 * @see changeAlign()
 	 * @param circle the Circle to copy
 	 * @param hAlign the HorizontalAlign to change to
 	 * @param vAlign the VerticalAlign to change to
 	 */
-	Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign vAlign);
+	Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept;
 
 	/**
 	 * @brief Circle constructor.
 	 * If you don't specify the alignment variables they will be set to the default values.
-	 * @throw std::invalid_argument if radius < 0
 	 * @param position the position
 	 * @param radius the radius
 	 * @param hAlign the HorizontalAlign
 	 * @param vAlign the VerticalAlign
 	 */
 	Circle(vec2<T> position, T radius, HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
-	                                   VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+	                                   VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN) noexcept;
 
 	/**
 	 * @brief Circle constructor.
 	 * If you don't specify the alignment variables they will be set to the default values.
-	 * @throw std::invalid_argument if radius < 0
 	 * @param x the x-position
 	 * @param y the y-position
 	 * @param radius the radius
@@ -96,7 +103,7 @@ public:
 	 * @param vAlign the VerticalAlign
 	 */
 	Circle(T x, T y, T radius, HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN,
-	                           VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+	                           VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN) noexcept;
 
 	~Circle() = default;
 
@@ -109,45 +116,45 @@ public:
 	 * @param point the specified vector
 	 * @return whether the specified vector is inside this Circle or not
 	 */
-	bool overlap(const vec2<T>& point) const;
+	bool overlap(const vec2<T>& point) const noexcept;
 
 	/**
 	 * @brief Returns whether the specified Circle overlaps with this Circle or not.
 	 * @param circle the specified circle
 	 * @return whether the specified Circle overlaps with this Circle or not
 	 */
-	bool overlap(const Circle<T>& circle) const;
+	bool overlap(const Circle<T>& circle) const noexcept;
 
 	/**
 	 * @brief Returns whether the specified Rectangle overlaps with this Circle or not.
 	 * @param rectangle the specified rectangle
 	 * @return whether the specified Rectangle overlaps with this Circle or not
 	 */
-	bool overlap(const Rectangle<T>& rect) const;
+	bool overlap(const Rectangle<T>& rect) const noexcept;
 
 	/**
 	 * @brief Returns the area of this Circle.
 	 * @return the area of this Circle
 	 */
-	T area() const;
+	T area() const noexcept;
 
 	/**
 	 * @brief Returns the circumference of this Circle.
 	 * @return the circumference of this Circle
 	 */
-	T circumference() const;
+	T circumference() const noexcept;
 
 	/**
 	 * @brief Hashes the rectangle.
 	 * @return hash of rectangle
 	 */
-	size_t hash() const;
+	size_t hash() const noexcept;
 
 	/**
 	 * @brief Returns string representation of the circle.
 	 * @return string representation of the circle
 	 */
-	std::string to_string() const;
+	std::string to_string() const noexcept;
 
 	/**
 	 * @brief Changes the HorizontalAlign and updates the position to reflect this.
@@ -155,7 +162,7 @@ public:
 	 * shifted. If this is not wanted mHorizontalAlign should be set directly.
 	 * @param hAlign the HorizontalAlign to set
 	 */
-	void changeHorizontalAlign(HorizontalAlign hAlign);
+	void changeHorizontalAlign(HorizontalAlign hAlign) noexcept;
 
 	/**
 	 * @brief Changes the VerticalAlign and updates the position to reflect this.
@@ -163,7 +170,16 @@ public:
 	 * shifted. If this is not wanted mVerticalAlign should be set directly.
 	 * @param vAlign the VerticalAlign to set
 	 */
-	void changeVerticalAlign(VerticalAlign vAlign);
+	void changeVerticalAlign(VerticalAlign vAlign) noexcept;
+
+	/**
+	 * @brief Changes the Horizontal and VerticalAlign and updates position to reflect this.
+	 * @see changeHorizontalAlign()
+	 * @see changeVerticalALign()
+	 * @param hAlign the HorizontalAlign to set
+	 * @param vAlign the VerticalAlign to set
+	 */
+	void changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign) noexcept;
 
 	// Getters
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -186,14 +202,14 @@ public:
 	 * @param other the rhs circle
 	 * @return whether the lhs and rhs circles are equal
 	 */
-	bool operator== (const Circle<T>& other) const;
+	bool operator== (const Circle<T>& other) const noexcept;
 
 	/**
 	 * @brief Inequality operator.
 	 * @param other the rhs circle
 	 * @return whether the lhs and rhs circles are not equal
 	 */
-	bool operator!= (const Circle<T>& other) const;
+	bool operator!= (const Circle<T>& other) const noexcept;
 
 	/**
 	 * @brief Smaller than operator.
@@ -202,7 +218,7 @@ public:
 	 * @param other the rhs circle
 	 * @return whether the lhs circle is smaller than the rhs circle
 	 */	
-	bool operator< (const Circle<T>& other) const;
+	bool operator< (const Circle<T>& other) const noexcept;
 
 	/**
 	 * @brief Larger than operator.
@@ -211,7 +227,7 @@ public:
 	 * @param other the rhs circle
 	 * @return whether the lhs circle is larger than the rhs circle
 	 */	
-	bool operator> (const Circle<T>& other) const;
+	bool operator> (const Circle<T>& other) const noexcept;
 
 	/**
 	 * @brief Smaller than or equal operator.
@@ -220,7 +236,7 @@ public:
 	 * @param other the rhs circle
 	 * @return whether the lhs circle is smaller than or equal to the rhs circle
 	 */	
-	bool operator<= (const Circle<T>& other) const;
+	bool operator<= (const Circle<T>& other) const noexcept;
 
 	/**
 	 * @brief Larger than or equal operator.
@@ -229,21 +245,7 @@ public:
 	 * @param other the rhs circle
 	 * @return whether the lhs circle is larger than or equal to the rhs circle
 	 */
-	bool operator>= (const Circle<T>& other) const;
-
-	// Members
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	vec2<T> mPos;
-	T mRadius;
-	HorizontalAlign mHorizontalAlign;
-	VerticalAlign mVerticalAlign;
-
-	// Private helper functions
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-private:
-
-	static T requireNonNegative(T value);
+	bool operator>= (const Circle<T>& other) const noexcept;
 };
 
 // Free (non-member) operators
@@ -258,7 +260,7 @@ private:
  * @return ostream the output straem
  */	
 template<typename T>
-std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle);
+std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle) noexcept;
 
 // Standard typedefs
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -282,7 +284,7 @@ namespace std {
 
 template<typename T>
 struct hash<sfz::Circle<T>> {
-	size_t operator() (const sfz::Circle<T>& circle) const;
+	size_t operator() (const sfz::Circle<T>& circle) const noexcept;
 };
 
 } // namespace std

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -5,6 +5,7 @@
 #include <functional> // std::hash
 #include <string>
 #include <cmath> // std::abs
+#include <cassert>
 #include "sfz/math/MathConstants.hpp"
 #include "sfz/math/Vector.hpp"
 #include "sfz/math/Alignment.hpp"
@@ -15,7 +16,7 @@ namespace sfz { template<typename T> class Rectangle; }
 namespace sfz {
 
 /**
- * @brief A class representing a Circle.
+ * @brief A POD class representing a Circle.
  *
  * All members are public and should be directly accessed, but there are a few convenience getters.
  *
@@ -42,6 +43,9 @@ public:
 	static const HorizontalAlign s_DEFAULT_HORIZONTAL_ALIGN;
 	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
 
+	/**
+	 * @brief [0] -> x-pos, [1] -> y-pos
+	 */
 	vec2<T> mPos;
 	T mRadius;
 	HorizontalAlign mHorizontalAlign;
@@ -50,8 +54,12 @@ public:
 	// Constructors and destructors
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	// No default constructor.
-	Circle() = delete;
+	/**
+	 * @brief Default constructor, value of elements undefined.
+	 * WARNING: The alignment members may end up with values outside their domain. A default
+	 * constructed circle should be considered uninitialized and should not be used or copied.
+	 */
+	Circle() = default;
 	
 	/**
 	 * @brief Basic copy-constructor.
@@ -155,6 +163,7 @@ public:
 	 * @brief Changes the HorizontalAlign and updates the position to reflect this.
 	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
 	 * shifted. If this is not wanted mHorizontalAlign should be set directly.
+	 * @assert mHorizontalAlign has a valid alignment
 	 * @param hAlign the HorizontalAlign to set
 	 */
 	void changeHorizontalAlign(HorizontalAlign hAlign) noexcept;
@@ -163,6 +172,7 @@ public:
 	 * @brief Changes the VerticalAlign and updates the position to reflect this.
 	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
 	 * shifted. If this is not wanted mVerticalAlign should be set directly.
+	 * @assert mVerticalAlign has a valid alignment
 	 * @param vAlign the VerticalAlign to set
 	 */
 	void changeVerticalAlign(VerticalAlign vAlign) noexcept;

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -44,7 +44,7 @@ public:
 	 */
 	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
 
-	// Public Members
+	// Public members
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 	vec2<T> mPos;

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -149,117 +149,34 @@ public:
 	 */
 	std::string to_string() const;
 
-	// Getters
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
 	/**
-	 * @brief Returns the position of this Circle.
-	 * @return position of this Circle
-	 */
-	vec2<T> getPosition() const;
-
-	/**
-	 * @brief Returns the x-position of this Circle.
-	 * @return x-position of this Circle
-	 */
-	T getX() const;
-	
-	/**
-	 * @brief Returns the y-position of this Circle.
-	 * @return y-position of this Circle
-	 */
-	T getY() const;
-
-	/**
-	 * @brief Returns the radius of this Circle.
-	 * @return radius of this Circle
-	 */
-	T getRadius() const;
-
-	/**
-	 * @brief Returns the HorizontalAlign of this Circle.
-	 * @return HorizontalAlign of this Circle
-	 */
-	HorizontalAlign getHorizontalAlign() const;
-
-	/**
-	 * @brief Returns the VerticalAlign of this Circle.
-	 * @return VerticalAlign of this Circle
-	 */
-	VerticalAlign getVerticalAlign() const;
-
-	// Setters
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	/**
-	 * @brief Sets the position.
-	 * @param position the position to set
-	 */
-	void setPosition(const vec2<T>& position);
-
-	/**
-	 * @brief Sets the position.
-	 * @param x the x-position to set
-	 * @param y the y-position to set
-	 */
-	void setPosition(T x, T y);
-
-	/**
-	 * @brief Sets the x-position.
-	 * @param x the x-position to set
-	 */
-	void setX(T x);
-
-	/**
-	 * @brief Sets the y-position.
-	 * @param y the y-position to set
-	 */
-	void setY(T y);
-
-	/**
-	 * @brief Sets the radius.
-	 * @throw std::invalid_argument if radius < 0
-	 * @param radius the radius to set
-	 */
-	void setRadius(T radius);
-
-	/**
-	 * @brief Simply sets the HorizontalAlign wihout doing anything else.
-	 * Doesn't update the position, so the Circle is actually shifted slightly by this function. If
-	 * this is unintended you should call changeHorizontalAlign() instead which also updates the
-	 * position.
-	 * @see changeHorizontalAlign()
-	 * @param hAlign the HorizontalAlign to set
-	 */
-	void setHorizontalAlign(HorizontalAlign hAlign);
-
-	/**
-	 * @brief Simply sets the VerticalAlign wihout doing anything else.
-	 * Doesn't update the position, so the Circle is actually shifted slightly by this function. If
-	 * this is unintended you should call changeVerticalAlign() instead which also updates the 
-	 * position.
-	 * @see changeVerticalAlign()
-	 * @param vAlign the VerticalAlign to set
-	 */
-	void setVerticalAlign(VerticalAlign vAlign);
-
-	/**
-	 * @brief Changes the HorizontalAlign and updates the internal position reflecting this.
+	 * @brief Changes the HorizontalAlign and updates the position to reflect this.
 	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
-	 * shifted. If this is not wanted setHorizontalAlign() should be used.
-	 * @see setHorizontalAlign()
+	 * shifted. If this is not wanted mHorizontalAlign should be set directly.
 	 * @param hAlign the HorizontalAlign to set
 	 */
 	void changeHorizontalAlign(HorizontalAlign hAlign);
 
 	/**
-	 * @brief Changes the VerticalAlign and updates the internal position reflecting this.
+	 * @brief Changes the VerticalAlign and updates the position to reflect this.
 	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
-	 * shifted. If this is not wanted setVerticalAlign() should be used.
-	 * @see setVerticalAlign()
+	 * shifted. If this is not wanted mVerticalAlign should be set directly.
 	 * @param vAlign the VerticalAlign to set
 	 */
 	void changeVerticalAlign(VerticalAlign vAlign);
+
+	// Getters
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @return x-position of this Circle.
+	 */
+	T x() const noexcept;
+
+	/**
+	 * @return y-position of this Circle.
+	 */
+	T y() const noexcept;
 
 	// Comparison operators
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -314,18 +231,17 @@ public:
 	 */
 	bool operator>= (const Circle<T>& other) const;
 
-private:
-
 	// Members
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	vec2<T> mPosition;
+	vec2<T> mPos;
 	T mRadius;
 	HorizontalAlign mHorizontalAlign;
 	VerticalAlign mVerticalAlign;
 
 	// Private helper functions
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+private:
 
 	static T requireNonNegative(T value);
 };

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -4,6 +4,7 @@
 
 #include <functional> // std::hash
 #include <string>
+#include <cmath> // std::abs
 #include "sfz/math/MathConstants.hpp"
 #include "sfz/math/Vector.hpp"
 #include "sfz/math/Alignment.hpp"
@@ -24,6 +25,10 @@ namespace sfz {
  * Beware if using integral types, some things like changing alignment and overlap checks might
  * mess up due to truncation.
  *
+ * Most functions wrap the radius in std::abs(), so they will treat a negative radius as a positive
+ * one. But you should still be careful and avoid a negative radius if possible, the results might
+ * still be a bit unpredictable.
+ *
  * @param T the element type
  *
  * @author Peter Hillerström <peter@hstroem.se>
@@ -31,21 +36,11 @@ namespace sfz {
 template<typename T>
 class Circle final {
 public:
-	// Static constants
+	// Static constants & public members
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	/**
-	 * @brief The default HorizontalAlign.
-	 */
 	static const HorizontalAlign s_DEFAULT_HORIZONTAL_ALIGN;
-
-	/**
-	 * @brief The default VerticalAlign.
-	 */
 	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
-
-	// Public members
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 	vec2<T> mPos;
 	T mRadius;

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -10,362 +10,366 @@
 #include "sfz/math/Alignment.hpp"
 
 // Forward declares Rectangle, is included after complete declaration of Circle.
-namespace sfz {
-	template<typename T>
-	class Rectangle;
-}
+namespace sfz { template<typename T> class Rectangle; }
 
 namespace sfz {
+
+/**
+ * @brief A class representing a Circle.
+ *
+ * The two alignment variables decide how the Circle is anchored to the position. Basically imagine
+ * an invsible square around the circle, BOTTOM LEFT is the bottom left corner on that square, etc.
+ *
+ * Beware if using integral types, some things like changing alignment and overlap checks might
+ * mess up due to truncation.
+ *
+ * @param T the element type
+ *
+ * @author Peter Hillerström <peter@hstroem.se>
+ */
+template<typename T>
+class Circle final {
+public:
+	// Static constants
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 	/**
-	 * @brief A class representing a Circle.
-	 *
-	 * The two alignment variables decide how the Circle is anchored to the position. Basically imagine an invsible
-	 * square around the circle, BOTTOM LEFT is the bottom left corner on that square, etc.
-	 *
-	 * Beware if using integral types, some things like changing alignment and overlap checks might mess up due to
-	 * truncation.
-	 *
-	 * @param T the element type
-	 *
-	 * @author Peter Hillerström <peter@hstroem.se>
-	 * @date 2014-08-08
+	 * @brief The default HorizontalAlign.
 	 */
-	template<typename T>
-	class Circle final {
-	public:
-		// Static constants
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief The default HorizontalAlign.
-		 */
-		static const HorizontalAlign DEFAULT_HORIZONTAL_ALIGN;
-
-		/**
-		 * @brief The default VerticalAlign.
-		 */
-		static const VerticalAlign DEFAULT_VERTICAL_ALIGN;
-
-		// Constructors and destructors
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		// No default constructor.
-		Circle() = delete;
-		
-		/**
-		 * @brief Basic copy-constructor.
-		 * @param circle the Circle to copy
-		 */
-		Circle(const Circle<T>& circle) = default;
-		
-		/**
-		 * @brief Copy cast constructor.
-		 * Attempts to static_cast all types from specified circle to specified type.
-		 * @param circle the circle to copy
-		 */
-		template<typename T2>
-		explicit Circle(const Circle<T2>& circle);
-
-		/**
-		 * @brief Copy constructor that changes alignment.
-		 * The alignment is changed as it would be if changeHorizontalAlign() or changeVerticalAlign() were called.
-		 * @param circle the Circle to copy
-		 * @param horizontalAlign the HorizontalAlign to change to
-		 * @param verticalAlign the VerticalAlign to change to
-		 */
-		Circle(const Circle<T>& circle, HorizontalAlign horizontalAlign, VerticalAlign verticalAlign);
-
-		/**
-		 * @brief Circle constructor.
-		 * If you don't specify the alignment variables they will be set to the default values.
-		 * @throw std::invalid_argument if radius < 0
-		 * @param position the position
-		 * @param radius the radius
-		 * @param horizontalAlign the HorizontalAlign
-		 * @param verticalAlign the VerticalAlign
-		 */
-		Circle(vec2<T> position, T radius, 
-		       HorizontalAlign horizontalAlign = DEFAULT_HORIZONTAL_ALIGN, 
-		       VerticalAlign verticalAlign = DEFAULT_VERTICAL_ALIGN);
-
-		/**
-		 * @brief Circle constructor.
-		 * If you don't specify the alignment variables they will be set to the default values.
-		 * @throw std::invalid_argument if radius < 0
-		 * @param x the x-position
-		 * @param y the y-position
-		 * @param radius the radius
-		 * @param horizontalAlign the HorizontalAlign
-		 * @param verticalAlign the VerticalAlign
-		 */
-		Circle(T x, T y, T radius,
-		       HorizontalAlign horizontalAlign = DEFAULT_HORIZONTAL_ALIGN, 
-		       VerticalAlign verticalAlign = DEFAULT_VERTICAL_ALIGN);
-
-		~Circle() = default;
-
-		// Public member functions
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Returns whether the specified vector is inside this Circle or not.
-		 * It's worth noting that this function uses 
-		 * @param point the specified vector
-		 * @return whether the specified vector is inside this Circle or not
-		 */
-		bool overlap(const vec2<T>& point) const;
-
-		/**
-		 * @brief Returns whether the specified Circle overlaps with this Circle or not.
-		 * @param circle the specified circle
-		 * @return whether the specified Circle overlaps with this Circle or not
-		 */
-		bool overlap(const Circle<T>& circle) const;
-
-		/**
-		 * @brief Returns whether the specified Rectangle overlaps with this Circle or not.
-		 * @param rectangle the specified rectangle
-		 * @return whether the specified Rectangle overlaps with this Circle or not
-		 */
-		bool overlap(const Rectangle<T>& rect) const;
-
-		/**
-		 * @brief Returns the area of this Circle.
-		 * @return the area of this Circle
-		 */
-		T area() const;
-
-		/**
-		 * @brief Returns the circumference of this Circle.
-		 * @return the circumference of this Circle
-		 */
-		T circumference() const;
-
-		/**
-		 * @brief Hashes the rectangle.
-		 * @return hash of rectangle
-		 */
-		size_t hash() const;
-
-		/**
-		 * @brief Returns string representation of the circle.
-		 * @return string representation of the circle
-		 */
-		std::string to_string() const;
-
-		// Getters
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Returns the position of this Circle.
-		 * @return position of this Circle
-		 */
-		vec2<T> getPosition() const;
-
-		/**
-		 * @brief Returns the x-position of this Circle.
-		 * @return x-position of this Circle
-		 */
-		T getX() const;
-		
-		/**
-		 * @brief Returns the y-position of this Circle.
-		 * @return y-position of this Circle
-		 */
-		T getY() const;
-
-		/**
-		 * @brief Returns the radius of this Circle.
-		 * @return radius of this Circle
-		 */
-		T getRadius() const;
-
-		/**
-		 * @brief Returns the HorizontalAlign of this Circle.
-		 * @return HorizontalAlign of this Circle
-		 */
-		HorizontalAlign getHorizontalAlign() const;
-
-		/**
-		 * @brief Returns the VerticalAlign of this Circle.
-		 * @return VerticalAlign of this Circle
-		 */
-		VerticalAlign getVerticalAlign() const;
-
-		// Setters
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Sets the position.
-		 * @param position the position to set
-		 */
-		void setPosition(const vec2<T>& position);
-
-		/**
-		 * @brief Sets the position.
-		 * @param x the x-position to set
-		 * @param y the y-position to set
-		 */
-		void setPosition(T x, T y);
-
-		/**
-		 * @brief Sets the x-position.
-		 * @param x the x-position to set
-		 */
-		void setX(T x);
-
-		/**
-		 * @brief Sets the y-position.
-		 * @param y the y-position to set
-		 */
-		void setY(T y);
-
-		/**
-		 * @brief Sets the radius.
-		 * @throw std::invalid_argument if radius < 0
-		 * @param radius the radius to set
-		 */
-		void setRadius(T radius);
-
-		/**
-		 * @brief Simply sets the HorizontalAlign wihout doing anything else.
-		 * Doesn't update the position, so the Circle is actually shifted slightly by this function. If this is
-		 * unintended you should call changeHorizontalAlign() instead which also updates the position.
-		 * @see changeHorizontalAlign()
-		 * @param horizontalAlign the HorizontalAlign to set
-		 */
-		void setHorizontalAlign(HorizontalAlign horizontalAlign);
-
-		/**
-		 * @brief Simply sets the VerticalAlign wihout doing anything else.
-		 * Doesn't update the position, so the Circle is actually shifted slightly by this function. If this is
-		 * unintended you should call changeVerticalAlign() instead which also updates the position.
-		 * @see changeVerticalAlign()
-		 * @param verticalAlign the VerticalAlign to set
-		 */
-		void setVerticalAlign(VerticalAlign verticalAlign);
-
-		/**
-		 * @brief Changes the HorizontalAlign of this Circle and updates the internal position reflecting this.
-		 * The position is updated so the Circle's actual position is the same afterwards, i.e. not shifted. If this
-		 * is not wanted setHorizontalAlign() should be used.
-		 * @see setHorizontalAlign()
-		 * @param horizontalAlign the HorizontalAlign to set
-		 */
-		void changeHorizontalAlign(HorizontalAlign horizontalAlign);
-
-		/**
-		 * @brief Changes the VerticalAlign of this Circle and updates the internal position reflecting this.
-		 * The position is updated so the Circle's actual position is the same afterwards, i.e. not shifted. If this
-		 * is not wanted setVerticalAlign() should be used.
-		 * @see setVerticalAlign()
-		 * @param verticalAlign the VerticalAlign to set
-		 */
-		void changeVerticalAlign(VerticalAlign verticalAlign);
-
-		// Comparison operators
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Equality operator.
-		 * @param other the rhs circle
-		 * @return whether the lhs and rhs circles are equal
-		 */
-		bool operator== (const Circle<T>& other) const;
-
-		/**
-		 * @brief Inequality operator.
-		 * @param other the rhs circle
-		 * @return whether the lhs and rhs circles are not equal
-		 */
-		bool operator!= (const Circle<T>& other) const;
-
-		/**
-		 * @brief Smaller than operator.
-		 * The size of the Circle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs circle
-		 * @return whether the lhs circle is smaller than the rhs circle
-		 */	
-		bool operator< (const Circle<T>& other) const;
-
-		/**
-		 * @brief Larger than operator.
-		 * The size of the Circle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs circle
-		 * @return whether the lhs circle is larger than the rhs circle
-		 */	
-		bool operator> (const Circle<T>& other) const;
-
-		/**
-		 * @brief Smaller than or equal operator.
-		 * The size of the Circle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs circle
-		 * @return whether the lhs circle is smaller than or equal to the rhs circle
-		 */	
-		bool operator<= (const Circle<T>& other) const;
-
-		/**
-		 * @brief Larger than or equal operator.
-		 * The size of the Circle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs circle
-		 * @return whether the lhs circle is larger than or equal to the rhs circle
-		 */
-		bool operator>= (const Circle<T>& other) const;
-
-	private:
-
-		// Members
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		vec2<T> position;
-		T radius;
-		HorizontalAlign horizontalAlign;
-		VerticalAlign verticalAlign;
-
-		// Private helper functions
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		static T requireNonNegative(T value);
-	};
-
-	// Free (non-member) operators
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	static const HorizontalAlign s_DEFAULT_HORIZONTAL_ALIGN;
 
 	/**
-	 * @relates sfz::Circle
-	 * @brief Ostream operator
-	 * The serialization of the circle is defined by its to_string() function.
-	 * @param ostream the output stream
-	 * @param circle the circle to serialize
-	 * @return ostream the output straem
+	 * @brief The default VerticalAlign.
+	 */
+	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
+
+	// Constructors and destructors
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	// No default constructor.
+	Circle() = delete;
+	
+	/**
+	 * @brief Basic copy-constructor.
+	 * @param circle the Circle to copy
+	 */
+	Circle(const Circle<T>& circle) = default;
+	
+	/**
+	 * @brief Copy cast constructor.
+	 * Attempts to static_cast all types from specified circle to specified type.
+	 * @param circle the circle to copy
+	 */
+	template<typename T2>
+	explicit Circle(const Circle<T2>& circle);
+
+	/**
+	 * @brief Copy constructor that changes alignment.
+	 * The alignment is changed as it would be if changeHorizontalAlign() or changeVerticalAlign()
+	 * were called.
+	 * @param circle the Circle to copy
+	 * @param hAlign the HorizontalAlign to change to
+	 * @param vAlign the VerticalAlign to change to
+	 */
+	Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign vAlign);
+
+	/**
+	 * @brief Circle constructor.
+	 * If you don't specify the alignment variables they will be set to the default values.
+	 * @throw std::invalid_argument if radius < 0
+	 * @param position the position
+	 * @param radius the radius
+	 * @param hAlign the HorizontalAlign
+	 * @param vAlign the VerticalAlign
+	 */
+	Circle(vec2<T> position, T radius, HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
+	                                   VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+
+	/**
+	 * @brief Circle constructor.
+	 * If you don't specify the alignment variables they will be set to the default values.
+	 * @throw std::invalid_argument if radius < 0
+	 * @param x the x-position
+	 * @param y the y-position
+	 * @param radius the radius
+	 * @param hAlign the HorizontalAlign
+	 * @param vAlign the VerticalAlign
+	 */
+	Circle(T x, T y, T radius, HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN,
+	                           VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+
+	~Circle() = default;
+
+	// Public member functions
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @brief Returns whether the specified vector is inside this Circle or not.
+	 * It's worth noting that this function uses 
+	 * @param point the specified vector
+	 * @return whether the specified vector is inside this Circle or not
+	 */
+	bool overlap(const vec2<T>& point) const;
+
+	/**
+	 * @brief Returns whether the specified Circle overlaps with this Circle or not.
+	 * @param circle the specified circle
+	 * @return whether the specified Circle overlaps with this Circle or not
+	 */
+	bool overlap(const Circle<T>& circle) const;
+
+	/**
+	 * @brief Returns whether the specified Rectangle overlaps with this Circle or not.
+	 * @param rectangle the specified rectangle
+	 * @return whether the specified Rectangle overlaps with this Circle or not
+	 */
+	bool overlap(const Rectangle<T>& rect) const;
+
+	/**
+	 * @brief Returns the area of this Circle.
+	 * @return the area of this Circle
+	 */
+	T area() const;
+
+	/**
+	 * @brief Returns the circumference of this Circle.
+	 * @return the circumference of this Circle
+	 */
+	T circumference() const;
+
+	/**
+	 * @brief Hashes the rectangle.
+	 * @return hash of rectangle
+	 */
+	size_t hash() const;
+
+	/**
+	 * @brief Returns string representation of the circle.
+	 * @return string representation of the circle
+	 */
+	std::string to_string() const;
+
+	// Getters
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @brief Returns the position of this Circle.
+	 * @return position of this Circle
+	 */
+	vec2<T> getPosition() const;
+
+	/**
+	 * @brief Returns the x-position of this Circle.
+	 * @return x-position of this Circle
+	 */
+	T getX() const;
+	
+	/**
+	 * @brief Returns the y-position of this Circle.
+	 * @return y-position of this Circle
+	 */
+	T getY() const;
+
+	/**
+	 * @brief Returns the radius of this Circle.
+	 * @return radius of this Circle
+	 */
+	T getRadius() const;
+
+	/**
+	 * @brief Returns the HorizontalAlign of this Circle.
+	 * @return HorizontalAlign of this Circle
+	 */
+	HorizontalAlign getHorizontalAlign() const;
+
+	/**
+	 * @brief Returns the VerticalAlign of this Circle.
+	 * @return VerticalAlign of this Circle
+	 */
+	VerticalAlign getVerticalAlign() const;
+
+	// Setters
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @brief Sets the position.
+	 * @param position the position to set
+	 */
+	void setPosition(const vec2<T>& position);
+
+	/**
+	 * @brief Sets the position.
+	 * @param x the x-position to set
+	 * @param y the y-position to set
+	 */
+	void setPosition(T x, T y);
+
+	/**
+	 * @brief Sets the x-position.
+	 * @param x the x-position to set
+	 */
+	void setX(T x);
+
+	/**
+	 * @brief Sets the y-position.
+	 * @param y the y-position to set
+	 */
+	void setY(T y);
+
+	/**
+	 * @brief Sets the radius.
+	 * @throw std::invalid_argument if radius < 0
+	 * @param radius the radius to set
+	 */
+	void setRadius(T radius);
+
+	/**
+	 * @brief Simply sets the HorizontalAlign wihout doing anything else.
+	 * Doesn't update the position, so the Circle is actually shifted slightly by this function. If
+	 * this is unintended you should call changeHorizontalAlign() instead which also updates the
+	 * position.
+	 * @see changeHorizontalAlign()
+	 * @param hAlign the HorizontalAlign to set
+	 */
+	void setHorizontalAlign(HorizontalAlign hAlign);
+
+	/**
+	 * @brief Simply sets the VerticalAlign wihout doing anything else.
+	 * Doesn't update the position, so the Circle is actually shifted slightly by this function. If
+	 * this is unintended you should call changeVerticalAlign() instead which also updates the 
+	 * position.
+	 * @see changeVerticalAlign()
+	 * @param vAlign the VerticalAlign to set
+	 */
+	void setVerticalAlign(VerticalAlign vAlign);
+
+	/**
+	 * @brief Changes the HorizontalAlign and updates the internal position reflecting this.
+	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
+	 * shifted. If this is not wanted setHorizontalAlign() should be used.
+	 * @see setHorizontalAlign()
+	 * @param hAlign the HorizontalAlign to set
+	 */
+	void changeHorizontalAlign(HorizontalAlign hAlign);
+
+	/**
+	 * @brief Changes the VerticalAlign and updates the internal position reflecting this.
+	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
+	 * shifted. If this is not wanted setVerticalAlign() should be used.
+	 * @see setVerticalAlign()
+	 * @param vAlign the VerticalAlign to set
+	 */
+	void changeVerticalAlign(VerticalAlign vAlign);
+
+	// Comparison operators
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @brief Equality operator.
+	 * @param other the rhs circle
+	 * @return whether the lhs and rhs circles are equal
+	 */
+	bool operator== (const Circle<T>& other) const;
+
+	/**
+	 * @brief Inequality operator.
+	 * @param other the rhs circle
+	 * @return whether the lhs and rhs circles are not equal
+	 */
+	bool operator!= (const Circle<T>& other) const;
+
+	/**
+	 * @brief Smaller than operator.
+	 * The size of the Circle is defined by the area() function, which is also what is compared in
+	 * this function.
+	 * @param other the rhs circle
+	 * @return whether the lhs circle is smaller than the rhs circle
 	 */	
-	template<typename T>
-	std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle);
+	bool operator< (const Circle<T>& other) const;
 
-	// Standard typedefs
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-	using CircleF = Circle<float>;
-	using CircleD = Circle<double>;
-	using CircleI = Circle<int>;
-	using CircleL = Circle<long>;
+	/**
+	 * @brief Larger than operator.
+	 * The size of the Circle is defined by the area() function, which is also what is compared in
+	 * this function.
+	 * @param other the rhs circle
+	 * @return whether the lhs circle is larger than the rhs circle
+	 */	
+	bool operator> (const Circle<T>& other) const;
 
-	template<typename T>
-	using circ = Circle<T>;
-	using circf = circ<float>;
-	using circd = circ<double>;
-	using circi = circ<int>;
-	using circl = circ<long>;
-}
+	/**
+	 * @brief Smaller than or equal operator.
+	 * The size of the Circle is defined by the area() function, which is also what is compared in
+	 * this function.
+	 * @param other the rhs circle
+	 * @return whether the lhs circle is smaller than or equal to the rhs circle
+	 */	
+	bool operator<= (const Circle<T>& other) const;
+
+	/**
+	 * @brief Larger than or equal operator.
+	 * The size of the Circle is defined by the area() function, which is also what is compared in
+	 * this function.
+	 * @param other the rhs circle
+	 * @return whether the lhs circle is larger than or equal to the rhs circle
+	 */
+	bool operator>= (const Circle<T>& other) const;
+
+private:
+
+	// Members
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	vec2<T> mPosition;
+	T mRadius;
+	HorizontalAlign mHorizontalAlign;
+	VerticalAlign mVerticalAlign;
+
+	// Private helper functions
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	static T requireNonNegative(T value);
+};
+
+// Free (non-member) operators
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+/**
+ * @relates sfz::Circle
+ * @brief Ostream operator
+ * The serialization of the circle is defined by its to_string() function.
+ * @param ostream the output stream
+ * @param circle the circle to serialize
+ * @return ostream the output straem
+ */	
+template<typename T>
+std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle);
+
+// Standard typedefs
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+using CircleF = Circle<float>;
+using CircleD = Circle<double>;
+using CircleI = Circle<int>;
+using CircleL = Circle<long>;
+
+template<typename T>
+using circ = Circle<T>;
+using circf = circ<float>;
+using circd = circ<double>;
+using circi = circ<int>;
+using circl = circ<long>;
+
+} // namespace sfz
 
 // Specializations of standard library for sfz::Circle
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 namespace std {
-	template<typename T>
-	struct hash<sfz::Circle<T>> {
-		size_t operator() (const sfz::Circle<T>& circle) const;
-	};
-}
+
+template<typename T>
+struct hash<sfz::Circle<T>> {
+	size_t operator() (const sfz::Circle<T>& circle) const;
+};
+
+} // namespace std
 
 #include "sfz/math/Rectangle.hpp"
 #include "Circle.inl"

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -137,6 +137,9 @@ std::string Circle<T>::to_string() const noexcept
 template<typename T>
 void Circle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 {
+	assert(mHorizontalAlign == HorizontalAlign::LEFT ||
+	       mHorizontalAlign == HorizontalAlign::CENTER ||
+	       mHorizontalAlign == HorizontalAlign::RIGHT);
 	mPos[0] = calculateNewPosition(mPos[0], mRadius*2, mHorizontalAlign, hAlign);
 	mHorizontalAlign = hAlign;
 }
@@ -144,6 +147,9 @@ void Circle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 template<typename T>
 void Circle<T>::changeVerticalAlign(VerticalAlign vAlign) noexcept
 {
+	assert(mVerticalAlign == VerticalAlign::BOTTOM ||
+	       mVerticalAlign == VerticalAlign::MIDDLE ||
+	       mVerticalAlign == VerticalAlign::TOP);
 	mPos[1] = calculateNewPosition(mPos[1], mRadius*2, mVerticalAlign, vAlign);
 	mVerticalAlign = vAlign;
 }

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -14,7 +14,7 @@ const VerticalAlign Circle<T>::s_DEFAULT_VERTICAL_ALIGN = VerticalAlign::MIDDLE;
 
 template<typename T>
 template<typename T2>
-Circle<T>::Circle(const Circle<T2>& circle)
+Circle<T>::Circle(const Circle<T2>& circle) noexcept
 :
 	mPos{static_cast<vec2<T2>>(circle.mPos)},
 	mHorizontalAlign{circle.mHorizontalAlign},
@@ -25,7 +25,7 @@ Circle<T>::Circle(const Circle<T2>& circle)
 
 
 template<typename T>
-Circle<T>::Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign vAlign)
+Circle<T>::Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	Circle<T>{circle}
 {
@@ -34,10 +34,10 @@ Circle<T>::Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign
 }
 
 template<typename T>
-Circle<T>::Circle(vec2<T> position, T radius, HorizontalAlign hAlign, VerticalAlign vAlign)
+Circle<T>::Circle(vec2<T> position, T radius, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{position},
-	mRadius{requireNonNegative(radius)},
+	mRadius{radius},
 	mHorizontalAlign{hAlign},
 	mVerticalAlign{vAlign}
 {
@@ -45,10 +45,10 @@ Circle<T>::Circle(vec2<T> position, T radius, HorizontalAlign hAlign, VerticalAl
 }
 
 template<typename T>
-Circle<T>::Circle(T x, T y, T radius, HorizontalAlign hAlign, VerticalAlign vAlign)
+Circle<T>::Circle(T x, T y, T radius, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{x, y},
-	mRadius{requireNonNegative(radius)},
+	mRadius{radius},
 	mHorizontalAlign{hAlign},
 	mVerticalAlign{vAlign}
 {
@@ -59,7 +59,7 @@ Circle<T>::Circle(T x, T y, T radius, HorizontalAlign hAlign, VerticalAlign vAli
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
-bool Circle<T>::overlap(const vec2<T>& point) const
+bool Circle<T>::overlap(const vec2<T>& point) const noexcept
 {
 	Circle<T> centerAlignCircle{*this, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
 
@@ -70,7 +70,7 @@ bool Circle<T>::overlap(const vec2<T>& point) const
 }
 
 template<typename T>
-bool Circle<T>::overlap(const Circle<T>& circle) const
+bool Circle<T>::overlap(const Circle<T>& circle) const noexcept
 {
 	Circle<T> centerAlignCircleThis{*this, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
 	Circle<T> centerAlignCircleOther{circle, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
@@ -84,25 +84,25 @@ bool Circle<T>::overlap(const Circle<T>& circle) const
 }
 
 template<typename T>
-bool Circle<T>::overlap(const Rectangle<T>& rect) const
+bool Circle<T>::overlap(const Rectangle<T>& rect) const noexcept
 {
 	return rect.overlap(*this);
 }
 
 template<typename T>
-T Circle<T>::area() const
+T Circle<T>::area() const noexcept
 {
 	return static_cast<T>(g_PI_DOUBLE)*mRadius*mRadius;
 }
 
 template<typename T>
-T Circle<T>::circumference() const
+T Circle<T>::circumference() const noexcept
 {
 	return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*mRadius;
 }
 
 template<typename T>
-size_t Circle<T>::hash() const
+size_t Circle<T>::hash() const noexcept
 {
 	std::hash<T> hasher;
 	std::hash<char> enumHasher;
@@ -119,7 +119,7 @@ size_t Circle<T>::hash() const
 }
 
 template<typename T>
-std::string Circle<T>::to_string() const
+std::string Circle<T>::to_string() const noexcept
 {
 	std::string str;
 	str += "[pos=";
@@ -135,17 +135,24 @@ std::string Circle<T>::to_string() const
 }
 
 template<typename T>
-void Circle<T>::changeHorizontalAlign(HorizontalAlign hAlign)
+void Circle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 {
 	mPos[0] = calculateNewPosition(mPos[0], mRadius*2, mHorizontalAlign, hAlign);
 	mHorizontalAlign = hAlign;
 }
 
 template<typename T>
-void Circle<T>::changeVerticalAlign(VerticalAlign vAlign)
+void Circle<T>::changeVerticalAlign(VerticalAlign vAlign) noexcept
 {
 	mPos[1] = calculateNewPosition(mPos[1], mRadius*2, mVerticalAlign, vAlign);
 	mVerticalAlign = vAlign;
+}
+
+template<typename T>
+void Circle<T>::changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
+{
+	changeHorizontalAlign(hAlign);
+	changeVerticalAlign(vAlign);
 }
 
 // Getters
@@ -167,7 +174,7 @@ T Circle<T>::y() const noexcept
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
-bool Circle<T>::operator== (const Circle<T>& other) const
+bool Circle<T>::operator== (const Circle<T>& other) const noexcept
 {
 	return mPos == other.mPos &&
 	       mRadius == other.mRadius &&
@@ -176,52 +183,40 @@ bool Circle<T>::operator== (const Circle<T>& other) const
 }
 
 template<typename T>
-bool Circle<T>::operator!= (const Circle<T>& other) const
+bool Circle<T>::operator!= (const Circle<T>& other) const noexcept
 {
 	return !((*this) == other);
 }
 
 template<typename T>
-bool Circle<T>::operator< (const Circle<T>& other) const
+bool Circle<T>::operator< (const Circle<T>& other) const noexcept
 {
 	return this->area() < other.area();
 }
 
 template<typename T>
-bool Circle<T>::operator> (const Circle<T>& other) const
+bool Circle<T>::operator> (const Circle<T>& other) const noexcept
 {
 	return this->area() > other.area();
 }
 
 template<typename T>
-bool Circle<T>::operator<= (const Circle<T>& other) const
+bool Circle<T>::operator<= (const Circle<T>& other) const noexcept
 {
 	return this->area() <= other.area();
 }
 
 template<typename T>
-bool Circle<T>::operator>= (const Circle<T>& other) const
+bool Circle<T>::operator>= (const Circle<T>& other) const noexcept
 {
 	return this->area() >= other.area();
-}
-
-// Private helper functions
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-template<typename T>
-T Circle<T>::requireNonNegative(T value)
-{
-	if (value < 0) {
-		throw std::invalid_argument{"Negative radius not allowed."};
-	}
-	return value;
 }
 
 // Free (non-member) operators
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
 
 template<typename T>
-std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle)
+std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle) noexcept
 {
 	return ostream << circle.to_string();
 }
@@ -233,7 +228,7 @@ std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle)
 namespace std {
 
 template<typename T>
-size_t hash<sfz::Circle<T>>::operator() (const sfz::Circle<T>& circle) const
+size_t hash<sfz::Circle<T>>::operator() (const sfz::Circle<T>& circle) const noexcept
 {
 	return circle.hash();
 }

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -1,265 +1,312 @@
 namespace sfz {
 
-	// Static constants
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// Static constants
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	template<typename T>
-	const HorizontalAlign Circle<T>::DEFAULT_HORIZONTAL_ALIGN = HorizontalAlign::CENTER;
+template<typename T>
+const HorizontalAlign Circle<T>::s_DEFAULT_HORIZONTAL_ALIGN = HorizontalAlign::CENTER;
 
-	template<typename T>
-	const VerticalAlign Circle<T>::DEFAULT_VERTICAL_ALIGN = VerticalAlign::MIDDLE;
+template<typename T>
+const VerticalAlign Circle<T>::s_DEFAULT_VERTICAL_ALIGN = VerticalAlign::MIDDLE;
 
-	// Constructors and destructors
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// Constructors and destructors
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	template<typename T>
-	template<typename T2>
-	Circle<T>::Circle(const Circle<T2>& circle) :
-		position{static_cast<vec2<T2>>(circle.getPosition())},
-		horizontalAlign{circle.getHorizontalAlign()},
-		verticalAlign{circle.getVerticalAlign()} {
-			this->radius = static_cast<T2>(circle.getRadius());
-	}
-
-
-	template<typename T>
-	Circle<T>::Circle(const Circle<T>& circle, HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		Circle<T>{circle} {
-			changeHorizontalAlign(horizontalAlign);
-			changeVerticalAlign(verticalAlign);
-	}
-
-	template<typename T>
-	Circle<T>::Circle(vec2<T> position, T radius, HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		position{position},
-		radius{requireNonNegative(radius)},
-		horizontalAlign{horizontalAlign},
-		verticalAlign{verticalAlign} {
-			// Initialization done.
-	}
-
-	template<typename T>
-	Circle<T>::Circle(T x, T y, T radius, HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		position{x, y},
-		radius{requireNonNegative(radius)},
-		horizontalAlign{horizontalAlign},
-		verticalAlign{verticalAlign} {
-			// Initialization done.
-	}
-
-	// Public member functions
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	bool Circle<T>::overlap(const vec2<T>& point) const {
-		Circle<T> centerAlignCircle{*this, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
-
-		// If the length from this circles center to the specified point is shorter than or equal to the radius then
-		// this Circle overlaps the point. Both sides of the equation is squared to avoid expensive sqrt() function.
-		return centerAlignCircle.position.distance(point).squaredNorm() <= radius*radius;
-	}
-
-	template<typename T>
-	bool Circle<T>::overlap(const Circle<T>& circle) const {
-		Circle<T> centerAlignCircleThis{*this, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
-		Circle<T> centerAlignCircleOther{circle, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
-
-		// If the length between the center of the two circles is less than or equal to the the sum of the circle's
-		// radiuses they overlap. Both sides of the equation is squared to avoid expensive sqrt() function.
-		T distSquared = centerAlignCircleThis.position.distance(centerAlignCircleOther.position).squaredNorm();
-		T radiusSum = centerAlignCircleThis.getRadius() + centerAlignCircleOther.getRadius();
-		return distSquared <= radiusSum * radiusSum;
-	}
-	
-	template<typename T>
-	bool Circle<T>::overlap(const Rectangle<T>& rect) const {
-		return rect.overlap(*this);
-	}
-
-	template<typename T>
-	T Circle<T>::area() const {
-		return static_cast<T>(g_PI_DOUBLE)*radius*radius;
-	}
-
-	template<typename T>
-	T Circle<T>::circumference() const {
-		return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*radius;
-	}
-
-	template<typename T>
-	size_t Circle<T>::hash() const {
-		std::hash<T> hasher;
-		std::hash<char> enumHasher;
-		size_t hash = 0;
-		// hash_combine algorithm from boost
-		hash ^= hasher(position[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= hasher(position[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= hasher(radius) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= enumHasher(static_cast<char>(horizontalAlign)) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= enumHasher(static_cast<char>(verticalAlign)) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		return hash;
-	}
-
-	template<typename T>
-	std::string Circle<T>::to_string() const {
-		std::string str;
-		str += "[pos=";
-		str += position.to_string();
-		str += ", r=";
-		str += std::to_string(radius);
-		str += ", align: ";
-		str += sfz::to_string(horizontalAlign);
-		str += ", ";
-		str += sfz::to_string(verticalAlign);
-		str += "]";
-		return std::move(str);
-	}
-
-	// Getters
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	vec2<T> Circle<T>::getPosition() const {
-		return position;
-	}
-
-	template<typename T>
-	T Circle<T>::getX() const {
-		return position[0];
-	}
-
-	template<typename T>
-	T Circle<T>::getY() const {
-		return position[1];
-	}
-
-	template<typename T>
-	T Circle<T>::getRadius() const {
-		return radius;
-	}
-
-	template<typename T>
-	HorizontalAlign Circle<T>::getHorizontalAlign() const {
-		return horizontalAlign;
-	}
-
-	template<typename T>
-	VerticalAlign Circle<T>::getVerticalAlign() const {
-		return verticalAlign;
-	}
-
-	// Setters
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	void Circle<T>::setPosition(const vec2<T>& position) {
-		this->position = position;
-	}
-
-	template<typename T>
-	void Circle<T>::setPosition(T x, T y) {
-		position[0] = x;
-		position[1] = y;
-	}
-
-	template<typename T>
-	void Circle<T>::setX(T x) {
-		this->position[0] = x;
-	}
-
-	template<typename T>
-	void Circle<T>::setY(T y) {
-		this->position[1] = y;
-	}
-
-	template<typename T>
-	void Circle<T>::setRadius(T radius) {
-		this->radius = requireNonNegative(radius);
-	}
-
-	template<typename T>
-	void Circle<T>::setHorizontalAlign(HorizontalAlign horizontalAlign) {
-		this->horizontalAlign = horizontalAlign;
-	}
-
-	template<typename T>
-	void Circle<T>::setVerticalAlign(VerticalAlign verticalAlign) {
-		this->verticalAlign = verticalAlign;
-	}
-
-	template<typename T>
-	void Circle<T>::changeHorizontalAlign(HorizontalAlign horizontalAlign) {
-		position[0] = calculateNewPosition(position[0], radius*2, this->horizontalAlign, horizontalAlign);
-		this->horizontalAlign = horizontalAlign;
-	}
-
-	template<typename T>
-	void Circle<T>::changeVerticalAlign(VerticalAlign verticalAlign) {
-		position[1] = calculateNewPosition(position[1], radius*2, this->verticalAlign, verticalAlign);
-		this->verticalAlign = verticalAlign;
-	}
-
-	// Comparison operators
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	bool Circle<T>::operator== (const Circle<T>& other) const {
-		return this->position == other.position &&
-		       this->radius == other.radius &&
-		       this->horizontalAlign == other.horizontalAlign &&
-		       this->verticalAlign == other.verticalAlign;
-	}
-
-	template<typename T>
-	bool Circle<T>::operator!= (const Circle<T>& other) const {
-		return !((*this) == other);
-	}
-
-	template<typename T>
-	bool Circle<T>::operator< (const Circle<T>& other) const {
-		return this->area() < other.area();
-	}
-
-	template<typename T>
-	bool Circle<T>::operator> (const Circle<T>& other) const {
-		return this->area() > other.area();
-	}
-
-	template<typename T>
-	bool Circle<T>::operator<= (const Circle<T>& other) const {
-		return this->area() <= other.area();
-	}
-
-	template<typename T>
-	bool Circle<T>::operator>= (const Circle<T>& other) const {
-		return this->area() >= other.area();
-	}
-
-	// Private helper functions
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	T Circle<T>::requireNonNegative(T value) {
-		if(value < 0) {
-			throw std::invalid_argument{"Negative radius not allowed."};
-		}
-		return value;
-	}
-
-	// Free (non-member) operators
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle) {
-		return ostream << circle.to_string();
-	}
+template<typename T>
+template<typename T2>
+Circle<T>::Circle(const Circle<T2>& circle)
+:
+	mPosition{static_cast<vec2<T2>>(circle.getPosition())},
+	mHorizontalAlign{circle.getHorizontalAlign()},
+	mVerticalAlign{circle.getVerticalAlign()}
+{
+	mRadius = static_cast<T2>(circle.getRadius());
 }
+
+
+template<typename T>
+Circle<T>::Circle(const Circle<T>& circle, HorizontalAlign hAlign, VerticalAlign vAlign)
+:
+	Circle<T>{circle}
+{
+	changeHorizontalAlign(hAlign);
+	changeVerticalAlign(vAlign);
+}
+
+template<typename T>
+Circle<T>::Circle(vec2<T> position, T radius, HorizontalAlign hAlign, VerticalAlign vAlign)
+:
+	mPosition{position},
+	mRadius{requireNonNegative(radius)},
+	mHorizontalAlign{hAlign},
+	mVerticalAlign{vAlign}
+{
+	// Initialization done.
+}
+
+template<typename T>
+Circle<T>::Circle(T x, T y, T radius, HorizontalAlign hAlign, VerticalAlign vAlign)
+:
+	mPosition{x, y},
+	mRadius{requireNonNegative(radius)},
+	mHorizontalAlign{hAlign},
+	mVerticalAlign{vAlign}
+{
+	// Initialization done.
+}
+
+// Public member functions
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+bool Circle<T>::overlap(const vec2<T>& point) const
+{
+	Circle<T> centerAlignCircle{*this, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
+
+	// If the length from this circles center to the specified point is shorter than or equal to
+	// the radius then this Circle overlaps the point. Both sides of the equation is squared to
+	// avoid somewhat expensive sqrt() function.
+	return centerAlignCircle.mPosition.distance(point).squaredNorm() <= mRadius*mRadius;
+}
+
+template<typename T>
+bool Circle<T>::overlap(const Circle<T>& circle) const
+{
+	Circle<T> centerAlignCircleThis{*this, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
+	Circle<T> centerAlignCircleOther{circle, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
+
+	// If the length between the center of the two circles is less than or equal to the the sum of
+	// the circle's radiuses they overlap. Both sides of the equation is squared to avoid somewhat 
+	// expensive sqrt() function.
+	T distSquared = centerAlignCircleThis.mPosition.distance(centerAlignCircleOther.mPosition)
+	                .squaredNorm();
+	T radiusSum = centerAlignCircleThis.mRadius + centerAlignCircleOther.mRadius;
+	return distSquared <= radiusSum * radiusSum;
+}
+
+template<typename T>
+bool Circle<T>::overlap(const Rectangle<T>& rect) const
+{
+	return rect.overlap(*this);
+}
+
+template<typename T>
+T Circle<T>::area() const
+{
+	return static_cast<T>(g_PI_DOUBLE)*mRadius*mRadius;
+}
+
+template<typename T>
+T Circle<T>::circumference() const
+{
+	return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*mRadius;
+}
+
+template<typename T>
+size_t Circle<T>::hash() const
+{
+	std::hash<T> hasher;
+	std::hash<char> enumHasher;
+	size_t hash = 0;
+	// hash_combine algorithm from boost
+	hash ^= hasher(mPosition[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= hasher(mPosition[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= hasher(mRadius) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= enumHasher(static_cast<char>(mHorizontalAlign)) +
+	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= enumHasher(static_cast<char>(mVerticalAlign)) + 
+	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
+	return hash;
+}
+
+template<typename T>
+std::string Circle<T>::to_string() const
+{
+	std::string str;
+	str += "[pos=";
+	str += mPosition.to_string();
+	str += ", r=";
+	str += std::to_string(mRadius);
+	str += ", align: ";
+	str += sfz::to_string(mHorizontalAlign);
+	str += ", ";
+	str += sfz::to_string(mVerticalAlign);
+	str += "]";
+	return std::move(str);
+}
+
+// Getters
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+vec2<T> Circle<T>::getPosition() const
+{
+	return mPosition;
+}
+
+template<typename T>
+T Circle<T>::getX() const
+{
+	return mPosition[0];
+}
+
+template<typename T>
+T Circle<T>::getY() const
+{
+	return mPosition[1];
+}
+
+template<typename T>
+T Circle<T>::getRadius() const
+{
+	return mRadius;
+}
+
+template<typename T>
+HorizontalAlign Circle<T>::getHorizontalAlign() const
+{
+	return mHorizontalAlign;
+}
+
+template<typename T>
+VerticalAlign Circle<T>::getVerticalAlign() const
+{
+	return mVerticalAlign;
+}
+
+// Setters
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+void Circle<T>::setPosition(const vec2<T>& position)
+{
+	mPosition = position;
+}
+
+template<typename T>
+void Circle<T>::setPosition(T x, T y)
+{
+	mPosition[0] = x;
+	mPosition[1] = y;
+}
+
+template<typename T>
+void Circle<T>::setX(T x)
+{
+	mPosition[0] = x;
+}
+
+template<typename T>
+void Circle<T>::setY(T y)
+{
+	mPosition[1] = y;
+}
+
+template<typename T>
+void Circle<T>::setRadius(T radius)
+{
+	mRadius = requireNonNegative(radius);
+}
+
+template<typename T>
+void Circle<T>::setHorizontalAlign(HorizontalAlign horizontalAlign)
+{
+	mHorizontalAlign = horizontalAlign;
+}
+
+template<typename T>
+void Circle<T>::setVerticalAlign(VerticalAlign verticalAlign)
+{
+	mVerticalAlign = verticalAlign;
+}
+
+template<typename T>
+void Circle<T>::changeHorizontalAlign(HorizontalAlign horizontalAlign)
+{
+	mPosition[0] = calculateNewPosition(mPosition[0], mRadius*2, mHorizontalAlign, horizontalAlign);
+	mHorizontalAlign = horizontalAlign;
+}
+
+template<typename T>
+void Circle<T>::changeVerticalAlign(VerticalAlign verticalAlign)
+{
+	mPosition[1] = calculateNewPosition(mPosition[1], mRadius*2, mVerticalAlign, verticalAlign);
+	mVerticalAlign = verticalAlign;
+}
+
+// Comparison operators
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+bool Circle<T>::operator== (const Circle<T>& other) const
+{
+	return mPosition == other.mPosition &&
+	       mRadius == other.mRadius &&
+	       mHorizontalAlign == other.mHorizontalAlign &&
+	       mVerticalAlign == other.mVerticalAlign;
+}
+
+template<typename T>
+bool Circle<T>::operator!= (const Circle<T>& other) const
+{
+	return !((*this) == other);
+}
+
+template<typename T>
+bool Circle<T>::operator< (const Circle<T>& other) const
+{
+	return this->area() < other.area();
+}
+
+template<typename T>
+bool Circle<T>::operator> (const Circle<T>& other) const
+{
+	return this->area() > other.area();
+}
+
+template<typename T>
+bool Circle<T>::operator<= (const Circle<T>& other) const
+{
+	return this->area() <= other.area();
+}
+
+template<typename T>
+bool Circle<T>::operator>= (const Circle<T>& other) const
+{
+	return this->area() >= other.area();
+}
+
+// Private helper functions
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+T Circle<T>::requireNonNegative(T value)
+{
+	if (value < 0) {
+		throw std::invalid_argument{"Negative radius not allowed."};
+	}
+	return value;
+}
+
+// Free (non-member) operators
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+std::ostream& operator<< (std::ostream& ostream, const Circle<T> circle)
+{
+	return ostream << circle.to_string();
+}
+
+} // namespace sfz
 
 // Specializations of standard library for sfz::Circle
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 namespace std {
-	template<typename T>
-	size_t hash<sfz::Circle<T>>::operator() (const sfz::Circle<T>& circle) const {
-		return circle.hash();
-	}
+
+template<typename T>
+size_t hash<sfz::Circle<T>>::operator() (const sfz::Circle<T>& circle) const
+{
+	return circle.hash();
 }
+
+} // namespace std

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -1,6 +1,6 @@
 namespace sfz {
 
-// Static constants
+// Static constants & public members
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
@@ -79,7 +79,7 @@ bool Circle<T>::overlap(const Circle<T>& circle) const noexcept
 	// the circle's radiuses they overlap. Both sides of the equation is squared to avoid somewhat 
 	// expensive sqrt() function.
 	T distSquared = centerAlignCircleThis.mPos.distance(centerAlignCircleOther.mPos).squaredNorm();
-	T radiusSum = centerAlignCircleThis.mRadius + centerAlignCircleOther.mRadius;
+	T radiusSum = std::abs(centerAlignCircleThis.mRadius) + std::abs(centerAlignCircleOther.mRadius);
 	return distSquared <= radiusSum * radiusSum;
 }
 
@@ -98,7 +98,7 @@ T Circle<T>::area() const noexcept
 template<typename T>
 T Circle<T>::circumference() const noexcept
 {
-	return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*mRadius;
+	return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*std::abs(mRadius);
 }
 
 template<typename T>

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -78,12 +78,12 @@ namespace sfz {
 
 	template<typename T>
 	T Circle<T>::area() const {
-		return static_cast<T>(PI_DOUBLE)*radius*radius;
+		return static_cast<T>(g_PI_DOUBLE)*radius*radius;
 	}
 
 	template<typename T>
 	T Circle<T>::circumference() const {
-		return static_cast<T>(2)*static_cast<T>(PI_DOUBLE)*radius;
+		return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*radius;
 	}
 
 	template<typename T>

--- a/include/sfz/math/MathConstants.hpp
+++ b/include/sfz/math/MathConstants.hpp
@@ -6,13 +6,14 @@
 
 namespace sfz {
 
-	const float PI_FLOAT{std::atan(1.0f)*4.0f};
-	const double PI_DOUBLE{std::atan(1.0)*4.0};
-	
-	const double DEG_TO_RAD_DOUBLE = PI_DOUBLE / 180.0;
-	const double RAD_TO_DEG_DOUBLE = 180.0 / PI_DOUBLE;
+const float g_PI_FLOAT{std::atan(1.0f)*4.0f};
+const double g_PI_DOUBLE{std::atan(1.0)*4.0};
 
-	const float DEG_TO_RAD_FLOAT = PI_FLOAT / 180.0f;
-	const float RAD_TO_DEG_FLOAT = 180.0f / PI_FLOAT;
-}
+const double g_DEG_TO_RAD_DOUBLE = g_PI_DOUBLE / 180.0;
+const double g_RAD_TO_DEG_DOUBLE = 180.0 / g_PI_DOUBLE;
+
+const float g_DEG_TO_RAD_FLOAT = g_PI_FLOAT / 180.0f;
+const float g_RAD_TO_DEG_FLOAT = 180.0f / g_PI_FLOAT;
+
+} // namespace sfz
 #endif

--- a/include/sfz/math/Rectangle.hpp
+++ b/include/sfz/math/Rectangle.hpp
@@ -6,6 +6,7 @@
 #include <functional> // std::hash
 #include <string>
 #include <iostream> // ostream
+#include <cmath> // std::abs
 #include "sfz/math/Vector.hpp"
 #include "sfz/math/Alignment.hpp"
 
@@ -14,402 +15,305 @@ namespace sfz { template<typename T> class Circle; }
 
 namespace sfz {
 
+/**
+ * @brief A class representing a Rectangle.
+ *
+ * All members are public and should be directly accessed, but there are a few convenience getters.
+ *
+ * The two alignment variables decide how the Rectangle is anchored to the position.
+ *
+ * Beware if using integral types, some things like changing alignment and overlap checks might
+ * mess up due to truncation.
+ *
+ * @param T the element type
+ *
+ * @author Peter Hillerström <peter@hstroem.se>
+ * @date 2014-08-08
+ */
+template<typename T>
+class Rectangle final {
+public:
+	// Static constants
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 	/**
-	 * @brief A class representing a Rectangle.
-	 *
-	 * The two alignment variables decide how the Rectangle is anchored to the position.
-	 *
-	 * Beware if using integral types, some things like changing alignment and overlap checks might mess up due to
-	 * truncation.
-	 *
-	 * @param T the element type
-	 *
-	 * @author Peter Hillerström <peter@hstroem.se>
-	 * @date 2014-08-08
+	 * @brief The default HorizontalAlign.
 	 */
-	template<typename T>
-	class Rectangle final {
-	public:
-		// Static constants
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief The default HorizontalAlign.
-		 */
-		static const HorizontalAlign DEFAULT_HORIZONTAL_ALIGN;
-
-		/**
-		 * @brief The default VerticalAlign.
-		 */
-		static const VerticalAlign DEFAULT_VERTICAL_ALIGN;
-
-		// Constructors and destructors
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		Rectangle() = delete;
-
-		/**
-		 * @brief Basic copy-constructor.
-		 * @param rect the Rectangle to copy
-		 */
-		Rectangle(const Rectangle<T>& rect) = default;
-
-		/**
-		 * @brief Copy cast constructor.
-		 * Attempts to static_cast all types from specified rectangle to specified type.
-		 * @param rect the rectangle to copy
-		 */
-		template<typename T2>
-		explicit Rectangle(const Rectangle<T2>& rect);
-
-		/**
-		 * @brief Copy constructor that changes alignment.
-		 * The alignment is changed as it would be if changeHorizontalAlign() or changeVerticalAlign() were called.
-		 * @param rect the Rectangle to copy
-		 * @param horizontalAlign the HorizontalAlign to change to
-		 * @param verticalAlign the VerticalAlign to change to
-		 */
-		Rectangle(const Rectangle<T>& rect, HorizontalAlign horizontalAlign, VerticalAlign verticalAlign);
-
-		/**
-		 * @brief Rectangle constructor.
-		 * If you don't specify the alignment variables they will be set to the default values.
-		 * @throw std::invalid_argument if width or height < 0
-		 * @param position the position
-		 * @param dimensions the dimensions
-		 * @param horizontalAlign the HorizontalAlign
-		 * @param verticalAlign the VerticalAlign
-		 */
-		Rectangle(const vec2<T>& position, const vec2<T>& dimensions, 
-		          HorizontalAlign horizontalAlign = DEFAULT_HORIZONTAL_ALIGN, 
-		          VerticalAlign verticalAlign = DEFAULT_VERTICAL_ALIGN);
-
-		/**
-		 * @brief Rectangle constructor.
-		 * If you don't specify the alignment variables they will be set to the default values.
-		 * @throw std::invalid_argument if width or height < 0
-		 * @param position the position
-		 * @param width the width
-		 * @param height the height
-		 * @param horizontalAlign the HorizontalAlign
-		 * @param verticalAlign the VerticalAlign
-		 */
-		Rectangle(const vec2<T>& position, T width, T height, 
-		          HorizontalAlign horizontalAlign = DEFAULT_HORIZONTAL_ALIGN, 
-		          VerticalAlign verticalAlign = DEFAULT_VERTICAL_ALIGN);
-
-		/**
-		 * @brief Rectangle constructor.
-		 * If you don't specify the alignment variables they will be set to the default values.
-		 * @throw std::invalid_argument if width or height < 0
-		 * @param x the x-position
-		 * @param y the y-position
-		 * @param width the width
-		 * @param height the height
-		 * @param horizontalAlign the HorizontalAlign
-		 * @param verticalAlign the VerticalAlign
-		 */
-		Rectangle(T x, T y, T width, T height, 
-		          HorizontalAlign horizontalAlign = DEFAULT_HORIZONTAL_ALIGN, 
-		          VerticalAlign verticalAlign = DEFAULT_VERTICAL_ALIGN);
-
-		~Rectangle() = default;
-
-		// Public member functions
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Returns whether the specified vector is inside this Rectangle or not.
-		 * It's worth noting that this function uses 
-		 * @param point the specified vector
-		 * @return whether the specified vector is inside this Rectangle or not
-		 */
-		bool overlap(const vec2<T>& point) const;
-
-		/**
-		 * @brief Returns whether the specified Rectangle overlaps with this Rectangle or not.
-		 * @param rectangle the specified rectangle
-		 * @return whether the specified Rectangle overlaps with this Rectangle or not
-		 */
-		bool overlap(const Rectangle<T>& rect) const;
-
-		/**
-		 * @brief Returns whether the specified Circle overlaps with this Rectangle or not.
-		 * @param circle the specified circle
-		 * @return whether the specified Circle overlaps with this Rectangle or not
-		 */
-		bool overlap(const Circle<T>& circle) const;
-
-		/**
-		 * @brief Returns the area of this Rectangle.
-		 * @return the area of this Rectangle
-		 */
-		T area() const;
-
-		/**
-		 * @brief Returns the circumference of this Rectangle.
-		 * @return the circumference of this Rectangle
-		 */
-		T circumference() const;
-
-		/**
-		 * @brief Hashes the rectangle.
-		 * @return hash of the rectangle
-		 */
-		size_t hash() const;
-
-		/**
-		 * @brief Returns string representation of the rectangle.
-		 * @return string representation of the rectangle
-		 */
-		std::string to_string() const;
-
-		// Getters
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Returns the position of this Rectangle.
-		 * @return position of this Rectangle
-		 */
-		vec2<T> getPosition() const;
-
-		/**
-		 * @brief Returns the x-position of this Rectangle.
-		 * @return x-position of this Rectangle
-		 */
-		T getX() const;
-
-		/**
-		 * @brief Returns the y-position of this Rectangle.
-		 * @return y-position of this Rectangle
-		 */
-		T getY() const;
-
-		/**
-		 * @brief Returns the dimensions of this Rectangle.
-		 * @return dimensions of this rectangle
-		 */
-		vec2<T> getDimensions() const;
-
-		/**
-		 * @brief Returns the width of this Rectangle.
-		 * @return width of this Rectangle
-		 */
-		T getWidth() const;
-
-		/**
-		 * @brief Returns the height of this Rectangle.
-		 * @return height of this Rectangle
-		 */
-		T getHeight() const;
-
-		/**
-		 * @brief Returns the HorizontalAlign of this Rectangle.
-		 * @return HorizontalAlign of this Rectangle
-		 */
-		HorizontalAlign getHorizontalAlign() const;
-
-		/**
-		 * @brief Returns the VerticalAlign of this Rectangle.
-		 * @return VerticalAlign of this Rectangle
-		 */
-		VerticalAlign getVerticalAlign() const;
-
-		// Setters
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Sets the position.
-		 * @param position the position to set
-		 */
-		void setPosition(const vec2<T>& position);
-
-		/**
-		 * @brief Sets the position.
-		 * @param x the x-position to set
-		 * @param y the y-position to set
-		 */
-		void setPosition(T x, T y);
-
-		/**
-		 * @brief Sets the x-position.
-		 * @param x the x-position to set
-		 */
-		void setX(T x);
-		
-		/**
-		 * @brief Sets the y-position.
-		 * @param y the y-position to set
-		 */
-		void setY(T y);
-
-		/**
-		 * @brief Sets the dimensions.
-		 * @throw std::invalid_argument if width or height < 0
-		 * @param dimensions the dimensions to set
-		 */
-		void setDimensions(const vec2<T>& dimensions);
-
-		/**
-		 * @brief Sets the dimensions.
-		 * @throw std::invalid_argument if width or height < 0
-		 * @param width the width to set
-		 * @param height the height to set
-		 */
-		void setDimensions(T width, T height);
-
-		/**
-		 * @brief Sets the width.
-		 * @throw std::invalid_argument if width < 0
-		 * @param width the width to set
-		 */
-		void setWidth(T width);
-
-		/**
-		 * @brief Sets the height.
-		 * @throw std::invalid_argument if height < 0
-		 * @param height the height to set
-		 */
-		void setHeight(T height);
-
-		/**
-		 * @brief Simply sets the HorizontalAlign wihout doing anything else.
-		 * Doesn't update the position, so the Rectangle is actually shifted slightly by this function. If this is
-		 * unintended you should call changeHorizontalAlign() instead which also updates the position.
-		 * @see changeHorizontalAlign()
-		 * @param horizontalAlign the HorizontalAlign to set
-		 */
-		void setHorizontalAlign(HorizontalAlign horizontalAlign);
-
-		/**
-		 * @brief Simply sets the VerticalAlign wihout doing anything else.
-		 * Doesn't update the position, so the Rectangle is actually shifted slightly by this function. If this is
-		 * unintended you should call changeVerticalAlign() instead which also updates the position.
-		 * @see changeVerticalAlign()
-		 * @param verticalAlign the VerticalAlign to set
-		 */
-		void setVerticalAlign(VerticalAlign verticalAlign);
-
-		/**
-		 * @brief Changes the HorizontalAlign of this Rectangle and updates the internal position reflecting this.
-		 * The position is updated so the Rectangle's actual position is the same afterwards, i.e. not shifted. If 
-		 * this is not wanted setHorizontalAlign() should be used.
-		 * @see setHorizontalAlign()
-		 * @param horizontalAlign the HorizontalAlign to set
-		 */
-		void changeHorizontalAlign(HorizontalAlign horizontalAlign);
-
-		/**
-		 * @brief Changes the VerticalAlign of this Rectangle and updates the internal position reflecting this.
-		 * The position is updated so the Rectangle's actual position is the same afterwards, i.e. not shifted. If
-		 * this is not wanted setVerticalAlign() should be used.
-		 * @see setVerticalAlign()
-		 * @param verticalAlign the VerticalAlign to set
-		 */
-		void changeVerticalAlign(VerticalAlign verticalAlign);
-
-		// Comparison operators
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/**
-		 * @brief Equality operator.
-		 * @param other the rhs rectangle
-		 * @return whether the lhs and rhs rectangles are equal
-		 */
-		bool operator== (const Rectangle<T>& other) const;
-
-		/**
-		 * @brief Inequality operator.
-		 * @param other the rhs rectangle
-		 * @return whether the lhs and rhs rectangles are not equal
-		 */
-		bool operator!= (const Rectangle<T>& other) const;
-
-		/**
-		 * @brief Smaller than operator.
-		 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs rectangle
-		 * @return whether the lhs rectangle is smaller than the rhs rectangle
-		 */	
-		bool operator< (const Rectangle<T>& other) const;
-
-		/**
-		 * @brief Larger than operator.
-		 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs rectangle
-		 * @return whether the lhs rectangle is larger than the rhs rectangle
-		 */	
-		bool operator> (const Rectangle<T>& other) const;
-
-		/**
-		 * @brief Smaller than or equal operator.
-		 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs rectangle
-		 * @return whether the lhs rectangle is smaller than or equal to the rhs rectangle
-		 */	
-		bool operator<= (const Rectangle<T>& other) const;
-
-		/**
-		 * @brief Larger than or equal operator.
-		 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
-		 * @param other the rhs rectangle
-		 * @return whether the lhs rectangle is larger than or equal to the rhs rectangle
-		 */	
-		bool operator>= (const Rectangle<T>& other) const;
-
-	private:
-
-		// Members
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		vec2<T> position;
-		vec2<T> dimensions;
-		HorizontalAlign horizontalAlign;
-		VerticalAlign verticalAlign;
-
-		// Private helper functions
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		static T requireNonNegative(T value);
-	};
-
-	// Free (non-member) operators
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	static const HorizontalAlign s_DEFAULT_HORIZONTAL_ALIGN;
 
 	/**
-	 * @relates sfz::Rectangle
-	 * @brief Ostream operator
-	 * The serialization of the rectangle is defined by its to_string() function.
-	 * @param ostream the output stream
-	 * @param rect the rectangle to serialize
-	 * @return ostream the output straem
+	 * @brief The default VerticalAlign.
+	 */
+	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
+
+	// Public members
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	vec2<T> mPos;
+	vec2<T> mDimensions;
+	HorizontalAlign mHorizontalAlign;
+	VerticalAlign mVerticalAlign;
+
+	// Constructors and destructors
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	Rectangle() = delete;
+
+	/**
+	 * @brief Basic copy-constructor.
+	 * @param rect the Rectangle to copy
+	 */
+	Rectangle(const Rectangle<T>& rect) = default;
+
+	/**
+	 * @brief Copy cast constructor.
+	 * Attempts to static_cast all types from specified rectangle to specified type.
+	 * @param rect the rectangle to copy
+	 */
+	template<typename T2>
+	explicit Rectangle(const Rectangle<T2>& rect);
+
+	/**
+	 * @brief Copy constructor that changes alignment.
+	 * The alignment is changed as it would be if changeHorizontalAlign() or changeVerticalAlign()
+	 * were called.
+	 * @param rect the Rectangle to copy
+	 * @param hAlign the HorizontalAlign to change to
+	 * @param vAlign the VerticalAlign to change to
+	 */
+	Rectangle(const Rectangle<T>& rect, HorizontalAlign hAlign, VerticalAlign vAlign);
+
+	/**
+	 * @brief Rectangle constructor.
+	 * If you don't specify the alignment variables they will be set to the default values.
+	 * @throw std::invalid_argument if width or height < 0
+	 * @param position the position
+	 * @param dimensions the dimensions
+	 * @param hAlign the HorizontalAlign
+	 * @param vAlign the VerticalAlign
+	 */
+	Rectangle(const vec2<T>& position, const vec2<T>& dimensions, 
+	          HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
+	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+
+	/**
+	 * @brief Rectangle constructor.
+	 * If you don't specify the alignment variables they will be set to the default values.
+	 * @throw std::invalid_argument if width or height < 0
+	 * @param position the position
+	 * @param width the width
+	 * @param height the height
+	 * @param hAlign the HorizontalAlign
+	 * @param vAlign the VerticalAlign
+	 */
+	Rectangle(const vec2<T>& position, T width, T height, 
+	          HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
+	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+
+	/**
+	 * @brief Rectangle constructor.
+	 * If you don't specify the alignment variables they will be set to the default values.
+	 * @throw std::invalid_argument if width or height < 0
+	 * @param x the x-position
+	 * @param y the y-position
+	 * @param width the width
+	 * @param height the height
+	 * @param hAlign the HorizontalAlign
+	 * @param vAlign the VerticalAlign
+	 */
+	Rectangle(T x, T y, T width, T height, 
+	          HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
+	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+
+	~Rectangle() = default;
+
+	// Public member functions
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @brief Returns whether the specified vector is inside this Rectangle or not.
+	 * It's worth noting that this function uses 
+	 * @param point the specified vector
+	 * @return whether the specified vector is inside this Rectangle or not
+	 */
+	bool overlap(const vec2<T>& point) const;
+
+	/**
+	 * @brief Returns whether the specified Rectangle overlaps with this Rectangle or not.
+	 * @param rectangle the specified rectangle
+	 * @return whether the specified Rectangle overlaps with this Rectangle or not
+	 */
+	bool overlap(const Rectangle<T>& rect) const;
+
+	/**
+	 * @brief Returns whether the specified Circle overlaps with this Rectangle or not.
+	 * @param circle the specified circle
+	 * @return whether the specified Circle overlaps with this Rectangle or not
+	 */
+	bool overlap(const Circle<T>& circle) const;
+
+	/**
+	 * @brief Returns the area of this Rectangle.
+	 * @return the area of this Rectangle
+	 */
+	T area() const;
+
+	/**
+	 * @brief Returns the circumference of this Rectangle.
+	 * @return the circumference of this Rectangle
+	 */
+	T circumference() const;
+
+	/**
+	 * @brief Hashes the rectangle.
+	 * @return hash of the rectangle
+	 */
+	size_t hash() const;
+
+	/**
+	 * @brief Returns string representation of the rectangle.
+	 * @return string representation of the rectangle
+	 */
+	std::string to_string() const;
+
+	/**
+	 * @brief Changes the HorizontalAlign of this Rectangle and updates the position.
+	 * The position is updated so the Rectangle's actual position is the same afterwards, i.e. not
+	 * shifted. If this is not wanted mHorizontalAlign should be set directly.
+	 * Even if the width is negative this function will behave as if it's positive.
+	 * @param hAlign the HorizontalAlign to set
+	 */
+	void changeHorizontalAlign(HorizontalAlign hAlign);
+
+	/**
+	 * @brief Changes the VerticalAlign of this Rectangle and updates the position.
+	 * The position is updated so the Rectangle's actual position is the same afterwards, i.e. not
+	 * shifted. If this is not wanted mVeritcalAlign should be set directly.
+	 * Even if the height is negative this function will behave as if it's positive.
+	 * @param vAlign the VerticalAlign to set
+	 */
+	void changeVerticalAlign(VerticalAlign vAlign);
+
+	/**
+	 * @brief Changes the Horizontal and VerticalAlign of this Rectangle and updates position
+	 * @see changeHorizontalAlign()
+	 * @see changeVerticalAlign()
+	 */
+	void changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign);
+
+	// Getters
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @return x-position of this Rectangle
+	 */
+	T x() const;
+
+	/**
+	 * @return y-position of this Rectangle
+	 */
+	T y() const;
+
+	/**
+	 * @return width of this Rectangle
+	 */
+	T width() const;
+
+	/**
+	 * @return height of this Rectangle
+	 */
+	T height() const;
+
+	// Comparison operators
+	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	/**
+	 * @brief Equality operator.
+	 * @param other the rhs rectangle
+	 * @return whether the lhs and rhs rectangles are equal
+	 */
+	bool operator== (const Rectangle<T>& other) const;
+
+	/**
+	 * @brief Inequality operator.
+	 * @param other the rhs rectangle
+	 * @return whether the lhs and rhs rectangles are not equal
+	 */
+	bool operator!= (const Rectangle<T>& other) const;
+
+	/**
+	 * @brief Smaller than operator.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * @param other the rhs rectangle
+	 * @return whether the lhs rectangle is smaller than the rhs rectangle
 	 */	
-	template<typename T>
-	std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect);
+	bool operator< (const Rectangle<T>& other) const;
 
-	// Standard typedefs
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-	using RectangleF = Rectangle<float>;
-	using RectangleD = Rectangle<double>;
-	using RectangleI = Rectangle<int>;
-	using RectangleL = Rectangle<long>;
+	/**
+	 * @brief Larger than operator.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * @param other the rhs rectangle
+	 * @return whether the lhs rectangle is larger than the rhs rectangle
+	 */	
+	bool operator> (const Rectangle<T>& other) const;
 
-	template<typename T>
-	using rect = Rectangle<T>;
-	using rectf = rect<float>;
-	using rectd = rect<double>;
-	using recti = rect<int>;
-	using rectl = rect<long>;
-}
+	/**
+	 * @brief Smaller than or equal operator.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * @param other the rhs rectangle
+	 * @return whether the lhs rectangle is smaller than or equal to the rhs rectangle
+	 */	
+	bool operator<= (const Rectangle<T>& other) const;
+
+	/**
+	 * @brief Larger than or equal operator.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * @param other the rhs rectangle
+	 * @return whether the lhs rectangle is larger than or equal to the rhs rectangle
+	 */	
+	bool operator>= (const Rectangle<T>& other) const;
+};
+
+// Free (non-member) operators
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+/**
+ * @relates sfz::Rectangle
+ * @brief Ostream operator
+ * The serialization of the rectangle is defined by its to_string() function.
+ * @param ostream the output stream
+ * @param rect the rectangle to serialize
+ * @return ostream the output straem
+ */	
+template<typename T>
+std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect);
+
+// Standard typedefs
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+using RectangleF = Rectangle<float>;
+using RectangleD = Rectangle<double>;
+using RectangleI = Rectangle<int>;
+using RectangleL = Rectangle<long>;
+
+template<typename T>
+using rect = Rectangle<T>;
+using rectf = rect<float>;
+using rectd = rect<double>;
+using recti = rect<int>;
+using rectl = rect<long>;
+
+} // namespace sfz
 
 // Specializations of standard library for sfz::Rectangle
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 namespace std {
-	template<typename T>
-	struct hash<sfz::Rectangle<T>> {
-		size_t operator() (const sfz::Rectangle<T>& rect) const;
-	};
-}
+
+template<typename T>
+struct hash<sfz::Rectangle<T>> {
+	size_t operator() (const sfz::Rectangle<T>& rect) const;
+};
+
+} // namespace std
 
 #include "sfz/math/Circle.hpp"
 #include "Rectangle.inl"

--- a/include/sfz/math/Rectangle.hpp
+++ b/include/sfz/math/Rectangle.hpp
@@ -2,7 +2,6 @@
 #ifndef SFZ_MATH_RECTANGLE_HPP
 #define SFZ_MATH_RECTANGLE_HPP
 
-#include <stdexcept> // std::invalid_argument
 #include <functional> // std::hash
 #include <string>
 #include <iostream> // ostream
@@ -25,6 +24,10 @@ namespace sfz {
  * Beware if using integral types, some things like changing alignment and overlap checks might
  * mess up due to truncation.
  *
+ * Most functions wrap the width and height in std::abs(), so they will treat a negative width or 
+ * height as a positive one. But you should still be careful and avoid negative widths and heights
+ * if possible, the results might still be a bit unpredictable.
+ *
  * @param T the element type
  *
  * @author Peter Hillerström <peter@hstroem.se>
@@ -33,21 +36,11 @@ namespace sfz {
 template<typename T>
 class Rectangle final {
 public:
-	// Static constants
+	// Static constants & public members
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	/**
-	 * @brief The default HorizontalAlign.
-	 */
 	static const HorizontalAlign s_DEFAULT_HORIZONTAL_ALIGN;
-
-	/**
-	 * @brief The default VerticalAlign.
-	 */
 	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
-
-	// Public members
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 	vec2<T> mPos;
 	vec2<T> mDimensions;
@@ -71,7 +64,7 @@ public:
 	 * @param rect the rectangle to copy
 	 */
 	template<typename T2>
-	explicit Rectangle(const Rectangle<T2>& rect);
+	explicit Rectangle(const Rectangle<T2>& rect) noexcept;
 
 	/**
 	 * @brief Copy constructor that changes alignment.
@@ -81,12 +74,11 @@ public:
 	 * @param hAlign the HorizontalAlign to change to
 	 * @param vAlign the VerticalAlign to change to
 	 */
-	Rectangle(const Rectangle<T>& rect, HorizontalAlign hAlign, VerticalAlign vAlign);
+	Rectangle(const Rectangle<T>& rect, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept;
 
 	/**
 	 * @brief Rectangle constructor.
 	 * If you don't specify the alignment variables they will be set to the default values.
-	 * @throw std::invalid_argument if width or height < 0
 	 * @param position the position
 	 * @param dimensions the dimensions
 	 * @param hAlign the HorizontalAlign
@@ -94,12 +86,11 @@ public:
 	 */
 	Rectangle(const vec2<T>& position, const vec2<T>& dimensions, 
 	          HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
-	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN) noexcept;
 
 	/**
 	 * @brief Rectangle constructor.
 	 * If you don't specify the alignment variables they will be set to the default values.
-	 * @throw std::invalid_argument if width or height < 0
 	 * @param position the position
 	 * @param width the width
 	 * @param height the height
@@ -108,12 +99,11 @@ public:
 	 */
 	Rectangle(const vec2<T>& position, T width, T height, 
 	          HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
-	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN) noexcept;
 
 	/**
 	 * @brief Rectangle constructor.
 	 * If you don't specify the alignment variables they will be set to the default values.
-	 * @throw std::invalid_argument if width or height < 0
 	 * @param x the x-position
 	 * @param y the y-position
 	 * @param width the width
@@ -123,7 +113,7 @@ public:
 	 */
 	Rectangle(T x, T y, T width, T height, 
 	          HorizontalAlign hAlign = s_DEFAULT_HORIZONTAL_ALIGN, 
-	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN);
+	          VerticalAlign vAlign = s_DEFAULT_VERTICAL_ALIGN) noexcept;
 
 	~Rectangle() = default;
 
@@ -136,45 +126,45 @@ public:
 	 * @param point the specified vector
 	 * @return whether the specified vector is inside this Rectangle or not
 	 */
-	bool overlap(const vec2<T>& point) const;
+	bool overlap(const vec2<T>& point) const noexcept;
 
 	/**
 	 * @brief Returns whether the specified Rectangle overlaps with this Rectangle or not.
 	 * @param rectangle the specified rectangle
 	 * @return whether the specified Rectangle overlaps with this Rectangle or not
 	 */
-	bool overlap(const Rectangle<T>& rect) const;
+	bool overlap(const Rectangle<T>& rect) const noexcept;
 
 	/**
 	 * @brief Returns whether the specified Circle overlaps with this Rectangle or not.
 	 * @param circle the specified circle
 	 * @return whether the specified Circle overlaps with this Rectangle or not
 	 */
-	bool overlap(const Circle<T>& circle) const;
+	bool overlap(const Circle<T>& circle) const noexcept;
 
 	/**
 	 * @brief Returns the area of this Rectangle.
 	 * @return the area of this Rectangle
 	 */
-	T area() const;
+	T area() const noexcept;
 
 	/**
 	 * @brief Returns the circumference of this Rectangle.
 	 * @return the circumference of this Rectangle
 	 */
-	T circumference() const;
+	T circumference() const noexcept;
 
 	/**
 	 * @brief Hashes the rectangle.
 	 * @return hash of the rectangle
 	 */
-	size_t hash() const;
+	size_t hash() const noexcept;
 
 	/**
 	 * @brief Returns string representation of the rectangle.
 	 * @return string representation of the rectangle
 	 */
-	std::string to_string() const;
+	std::string to_string() const noexcept;
 
 	/**
 	 * @brief Changes the HorizontalAlign of this Rectangle and updates the position.
@@ -183,7 +173,7 @@ public:
 	 * Even if the width is negative this function will behave as if it's positive.
 	 * @param hAlign the HorizontalAlign to set
 	 */
-	void changeHorizontalAlign(HorizontalAlign hAlign);
+	void changeHorizontalAlign(HorizontalAlign hAlign) noexcept;
 
 	/**
 	 * @brief Changes the VerticalAlign of this Rectangle and updates the position.
@@ -192,14 +182,14 @@ public:
 	 * Even if the height is negative this function will behave as if it's positive.
 	 * @param vAlign the VerticalAlign to set
 	 */
-	void changeVerticalAlign(VerticalAlign vAlign);
+	void changeVerticalAlign(VerticalAlign vAlign) noexcept;
 
 	/**
 	 * @brief Changes the Horizontal and VerticalAlign of this Rectangle and updates position
 	 * @see changeHorizontalAlign()
 	 * @see changeVerticalAlign()
 	 */
-	void changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign);
+	void changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign) noexcept;
 
 	// Getters
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -207,22 +197,22 @@ public:
 	/**
 	 * @return x-position of this Rectangle
 	 */
-	T x() const;
+	T x() const noexcept;
 
 	/**
 	 * @return y-position of this Rectangle
 	 */
-	T y() const;
+	T y() const noexcept;
 
 	/**
 	 * @return width of this Rectangle
 	 */
-	T width() const;
+	T width() const noexcept;
 
 	/**
 	 * @return height of this Rectangle
 	 */
-	T height() const;
+	T height() const noexcept;
 
 	// Comparison operators
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -232,46 +222,50 @@ public:
 	 * @param other the rhs rectangle
 	 * @return whether the lhs and rhs rectangles are equal
 	 */
-	bool operator== (const Rectangle<T>& other) const;
+	bool operator== (const Rectangle<T>& other) const noexcept;
 
 	/**
 	 * @brief Inequality operator.
 	 * @param other the rhs rectangle
 	 * @return whether the lhs and rhs rectangles are not equal
 	 */
-	bool operator!= (const Rectangle<T>& other) const;
+	bool operator!= (const Rectangle<T>& other) const noexcept;
 
 	/**
 	 * @brief Smaller than operator.
-	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared
+	 * in this function.
 	 * @param other the rhs rectangle
 	 * @return whether the lhs rectangle is smaller than the rhs rectangle
 	 */	
-	bool operator< (const Rectangle<T>& other) const;
+	bool operator< (const Rectangle<T>& other) const noexcept;
 
 	/**
 	 * @brief Larger than operator.
-	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared
+	 * in this function.
 	 * @param other the rhs rectangle
 	 * @return whether the lhs rectangle is larger than the rhs rectangle
 	 */	
-	bool operator> (const Rectangle<T>& other) const;
+	bool operator> (const Rectangle<T>& other) const noexcept;
 
 	/**
 	 * @brief Smaller than or equal operator.
-	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared
+	 * in this function.
 	 * @param other the rhs rectangle
 	 * @return whether the lhs rectangle is smaller than or equal to the rhs rectangle
 	 */	
-	bool operator<= (const Rectangle<T>& other) const;
+	bool operator<= (const Rectangle<T>& other) const noexcept;
 
 	/**
 	 * @brief Larger than or equal operator.
-	 * The size of the Rectangle is defined by the area() function, which is also what is compared in this function.
+	 * The size of the Rectangle is defined by the area() function, which is also what is compared
+	 * in this function.
 	 * @param other the rhs rectangle
 	 * @return whether the lhs rectangle is larger than or equal to the rhs rectangle
 	 */	
-	bool operator>= (const Rectangle<T>& other) const;
+	bool operator>= (const Rectangle<T>& other) const noexcept;
 };
 
 // Free (non-member) operators
@@ -286,7 +280,7 @@ public:
  * @return ostream the output straem
  */	
 template<typename T>
-std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect);
+std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect) noexcept;
 
 // Standard typedefs
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -310,7 +304,7 @@ namespace std {
 
 template<typename T>
 struct hash<sfz::Rectangle<T>> {
-	size_t operator() (const sfz::Rectangle<T>& rect) const;
+	size_t operator() (const sfz::Rectangle<T>& rect) const noexcept;
 };
 
 } // namespace std

--- a/include/sfz/math/Rectangle.hpp
+++ b/include/sfz/math/Rectangle.hpp
@@ -10,10 +10,7 @@
 #include "sfz/math/Alignment.hpp"
 
 // Forward declares Circle, is included after complete declaration of Rectangle.
-namespace sfz {
-	template<typename T>
-	class Circle;
-}
+namespace sfz { template<typename T> class Circle; }
 
 namespace sfz {
 

--- a/include/sfz/math/Rectangle.hpp
+++ b/include/sfz/math/Rectangle.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <iostream> // ostream
 #include <cmath> // std::abs
+#include <cassert>
 #include "sfz/math/Vector.hpp"
 #include "sfz/math/Alignment.hpp"
 
@@ -15,7 +16,7 @@ namespace sfz { template<typename T> class Circle; }
 namespace sfz {
 
 /**
- * @brief A class representing a Rectangle.
+ * @brief A POD class representing a Rectangle.
  *
  * All members are public and should be directly accessed, but there are a few convenience getters.
  *
@@ -42,7 +43,13 @@ public:
 	static const HorizontalAlign s_DEFAULT_HORIZONTAL_ALIGN;
 	static const VerticalAlign s_DEFAULT_VERTICAL_ALIGN;
 
+	/**
+	 * @brief [0] -> x-pos, [1] -> y-pos
+	 */
 	vec2<T> mPos;
+	/**
+	 * @brief [0] -> width, [1] -> height
+	 */
 	vec2<T> mDimensions;
 	HorizontalAlign mHorizontalAlign;
 	VerticalAlign mVerticalAlign;
@@ -50,7 +57,12 @@ public:
 	// Constructors and destructors
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	Rectangle() = delete;
+	/**
+	 * @brief Default constructor, value of elements undefined.
+	 * WARNING: The alignment members may end up with values outside their domain. A default
+	 * constructed rectangle should be considered uninitialized and should not be used or copied.
+	 */
+	Rectangle() = default;
 
 	/**
 	 * @brief Basic copy-constructor.

--- a/include/sfz/math/Rectangle.inl
+++ b/include/sfz/math/Rectangle.inl
@@ -1,353 +1,307 @@
 namespace sfz {
 
-	// Static constants
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// Static constants
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	template<typename T>
-	const HorizontalAlign Rectangle<T>::DEFAULT_HORIZONTAL_ALIGN = HorizontalAlign::CENTER;
+template<typename T>
+const HorizontalAlign Rectangle<T>::s_DEFAULT_HORIZONTAL_ALIGN = HorizontalAlign::CENTER;
 
-	template<typename T>
-	const VerticalAlign Rectangle<T>::DEFAULT_VERTICAL_ALIGN = VerticalAlign::MIDDLE;
+template<typename T>
+const VerticalAlign Rectangle<T>::s_DEFAULT_VERTICAL_ALIGN = VerticalAlign::MIDDLE;
 
-	// Constructors and destructors
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// Constructors and destructors
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-	template<typename T>
-	template<typename T2>
-	Rectangle<T>::Rectangle(const Rectangle<T2>& rect) :
-		position{static_cast<vec2<T2>>(rect.getPosition())},
-		dimensions{static_cast<vec2<T2>>(rect.getDimensions())},
-		horizontalAlign{rect.getHorizontalAlign()},
-		verticalAlign{rect.getVerticalAlign()} {
-			// Initialization done.
-	}
-
-	template<typename T>
-	Rectangle<T>::Rectangle(const Rectangle<T>& rect, HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		Rectangle<T>{rect} {
-			changeHorizontalAlign(horizontalAlign);
-			changeVerticalAlign(verticalAlign);
-	}
-
-	template<typename T>
-	Rectangle<T>::Rectangle(const vec2<T>& position, const vec2<T>& dimensions, 
-		                    HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		position{position}, 
-		dimensions{requireNonNegative(dimensions[0]), requireNonNegative(dimensions[1])},
-		horizontalAlign{horizontalAlign},
-		verticalAlign{verticalAlign} {
-			// Initialization done.
-	}
-	
-	template<typename T>
-	Rectangle<T>::Rectangle(const vec2<T>& position, T width, T height,
-		                    HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		position{position},
-		dimensions{requireNonNegative(width), requireNonNegative(height)},
-		horizontalAlign{horizontalAlign},
-		verticalAlign{verticalAlign} {
-			// Initialization done.
-	}
-
-	template<typename T>
-	Rectangle<T>::Rectangle(T x, T y, T width, T height,
-	                        HorizontalAlign horizontalAlign, VerticalAlign verticalAlign) :
-		position{x, y},
-		dimensions{requireNonNegative(width), requireNonNegative(height)},
-		horizontalAlign{horizontalAlign},
-		verticalAlign{verticalAlign} {
-			// Initialization done.
-	}
-
-	// Public member functions
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	bool Rectangle<T>::overlap(const vec2<T>& point) const {
-		Rectangle<T> leftBottomAlignRect{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
-
-		T rectXLeft = leftBottomAlignRect.getX();
-		T rectXRight = rectXLeft + leftBottomAlignRect.getWidth();
-		T rectYBottom = leftBottomAlignRect.getY();
-		T rectYTop = rectYBottom + leftBottomAlignRect.getHeight();
-		T vecX = point[0];
-		T vecY = point[1];
-
-		return rectXLeft <= vecX && rectXRight >= vecX &&
-		       rectYBottom <= vecY && rectYTop>= vecY;
-	}
-
-	template<typename T>
-	bool Rectangle<T>::overlap(const Rectangle<T>& rect) const {
-		Rectangle<T> leftBottomAlignRectThis{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
-		Rectangle<T> leftBottomAlignRectOther{rect, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
-
-		T thisXLeft = leftBottomAlignRectThis.getX();
-		T thisXRight = thisXLeft + leftBottomAlignRectThis.getWidth();
-		T thisYBottom = leftBottomAlignRectThis.getY();
-		T thisYTop = thisYBottom + leftBottomAlignRectThis.getHeight();
-
-		T otherXLeft = leftBottomAlignRectOther.getX();
-		T otherXRight = otherXLeft + leftBottomAlignRectOther.getWidth();
-		T otherYBottom = leftBottomAlignRectOther.getY();
-		T otherYTop = otherYBottom + leftBottomAlignRectOther.getHeight();
-
-		return thisXLeft   <= otherXRight &&
-		       thisXRight  >= otherXLeft &&
-		       thisYBottom <= otherYTop &&
-		       thisYTop    >= otherYBottom;
-	}
-
-	template<typename T>
-	bool Rectangle<T>::overlap(const Circle<T>& circle) const {
-		Rectangle<T> leftBottomAlignRect{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
-		Circle<T> centerAlignCircle{circle, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
-
-		T rectXLeft = leftBottomAlignRect.getX();
-		T rectXRight = rectXLeft + leftBottomAlignRect.getWidth();
-		T rectYBottom = leftBottomAlignRect.getY();
-		T rectYTop = rectYBottom + leftBottomAlignRect.getHeight();
-
-		T circleX = centerAlignCircle.x();
-		T circleY = centerAlignCircle.y();
-		T radius = centerAlignCircle.mRadius;
-
-		// If the length between the center of the circle and the closest point on the rectangle is less than or equal
-		// to the circles radius they overlap. Both sides of the equation is squared to avoid expensive sqrt() 
-		// function. 
-		T closestX = circleX;
-		T closestY = circleY;
-		
-		if(circleX <= rectXLeft) {
-			closestX = rectXLeft;
-		} 
-		else if(circleX >= rectXRight) {
-			closestX = rectXRight;
-		}
-		
-		if(circleY <= rectYBottom) {
-			closestY = rectYBottom;
-		}
-		else if(circleY >= rectYTop) {
-			closestY = rectYTop;
-		}
-		
-		return centerAlignCircle.mPos.distance(sfz::vec2<T>{closestX, closestY}).squaredNorm() 
-		       <= radius*radius;
-	}
-
-	template<typename T>
-	T Rectangle<T>::area() const {
-		return dimensions[0]*dimensions[1];
-	}
-
-	template<typename T>
-	T Rectangle<T>::circumference() const {
-		return dimensions[0]*2 + dimensions[1]*2;
-	}
-
-	template<typename T>
-	size_t Rectangle<T>::hash() const {
-		std::hash<T> hasher;
-		std::hash<char> enumHasher;
-		size_t hash = 0;
-		// hash_combine algorithm from boost
-		hash ^= hasher(position[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= hasher(position[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= hasher(dimensions[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= hasher(dimensions[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= enumHasher(static_cast<char>(horizontalAlign)) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		hash ^= enumHasher(static_cast<char>(verticalAlign)) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-		return hash;
-	}
-
-	template<typename T>
-	std::string Rectangle<T>::to_string() const {
-		std::string str;
-		str += "[pos=";
-		str += position.to_string();
-		str += ", dim=";
-		str += dimensions.to_string();
-		str += ", align: ";
-		str += sfz::to_string(horizontalAlign);
-		str += ", ";
-		str += sfz::to_string(verticalAlign);
-		str += "]";
-		return std::move(str);
-	}
-
-	// Getters
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	vec2<T> Rectangle<T>::getPosition() const {
-		return position;
-	}
-
-	template<typename T>
-	T Rectangle<T>::getX() const {
-		return position[0];
-	}
-
-	template<typename T>
-	T Rectangle<T>::getY() const {
-		return position[1];
-	}
-
-	template<typename T>
-	vec2<T> Rectangle<T>::getDimensions() const {
-		return dimensions;
-	}
-
-	template<typename T>
-	T Rectangle<T>::getWidth() const {
-		return dimensions[0];
-	}
-
-	template<typename T>
-	T Rectangle<T>::getHeight() const {
-		return dimensions[1];
-	}
-
-	template<typename T>
-	HorizontalAlign Rectangle<T>::getHorizontalAlign() const {
-		return horizontalAlign;
-	}
-	
-	template<typename T>
-	VerticalAlign Rectangle<T>::getVerticalAlign() const {
-		return verticalAlign;
-	}
-
-	// Setters
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	void Rectangle<T>::setPosition(const vec2<T>& position) {
-		this->position = position;
-	}
-
-	template<typename T>
-	void Rectangle<T>::setPosition(T x, T y) {
-		position[0] = x;
-		position[1] = y;
-	}
-
-	template<typename T>
-	void Rectangle<T>::setX(T x) {
-		position[0] = x;
-	}
-
-	template<typename T>
-	void Rectangle<T>::setY(T y) {
-		position[1] = y;
-	}
-
-	template<typename T>
-	void Rectangle<T>::setDimensions(const vec2<T>& dimensions) {
-		this->dimensions[0] = requireNonNegative(dimensions[0]);
-		this->dimensions[1] = requireNonNegative(dimensions[1]);
-	}
-
-	template<typename T>
-	void Rectangle<T>::setDimensions(T width, T height) {
-		dimensions[0] = requireNonNegative(width);
-		dimensions[1] = requireNonNegative(height);
-	}
-
-	template<typename T>
-	void Rectangle<T>::setWidth(T width) {
-		dimensions[0] = requireNonNegative(width);
-	}
-
-	template<typename T>
-	void Rectangle<T>::setHeight(T height) {
-		dimensions[1] = requireNonNegative(height);
-	}
-
-	template<typename T>
-	void Rectangle<T>::setHorizontalAlign(HorizontalAlign horizontalAlign) {
-		this->horizontalAlign = horizontalAlign;
-	}
-
-	template<typename T>
-	void Rectangle<T>::setVerticalAlign(VerticalAlign verticalAlign) {
-		this->verticalAlign = verticalAlign;
-	}
-
-	template<typename T>
-	void Rectangle<T>::changeHorizontalAlign(HorizontalAlign horizontalAlign) {
-		position[0] = calculateNewPosition(position[0], dimensions[0], this->horizontalAlign, horizontalAlign);
-		this->horizontalAlign = horizontalAlign;
-	}
-
-	template<typename T>
-	void Rectangle<T>::changeVerticalAlign(VerticalAlign verticalAlign) {
-		position[1] = calculateNewPosition(position[1], dimensions[1], this->verticalAlign, verticalAlign);
-		this->verticalAlign = verticalAlign;
-	}
-
-	// Comparison operators
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	bool Rectangle<T>::operator== (const Rectangle<T>& other) const {
-		return this->position == other.position &&
-		       this->dimensions == other.dimensions &&
-		       this->horizontalAlign == other.horizontalAlign &&
-		       this->verticalAlign == other.verticalAlign;
-	}
-
-	template<typename T>
-	bool Rectangle<T>::operator!= (const Rectangle<T>& other) const {
-		return !((*this) == other);
-	}
-
-	template<typename T>
-	bool Rectangle<T>::operator< (const Rectangle<T>& other) const {
-		return this->area() < other.area();
-	}
-
-	template<typename T>
-	bool Rectangle<T>::operator> (const Rectangle<T>& other) const {
-		return this->area() > other.area();
-	}
-
-	template<typename T>
-	bool Rectangle<T>::operator<= (const Rectangle<T>& other) const {
-		return this->area() <= other.area();
-	}
-
-	template<typename T>
-	bool Rectangle<T>::operator>= (const Rectangle<T>& other) const {
-		return this->area() >= other.area();
-	}
-
-	// Private helper functions
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	T Rectangle<T>::requireNonNegative(T value) {
-		if(value < 0) {
-			throw std::invalid_argument{"Negative dimensions not allowed."};
-		}
-		return value;
-	}
-
-	// Free (non-member) operators
-	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-	template<typename T>
-	std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect) {
-		return ostream << rect.to_string();
-	}
+template<typename T>
+template<typename T2>
+Rectangle<T>::Rectangle(const Rectangle<T2>& rect)
+:
+	mPos{static_cast<vec2<T2>>(rect.mPos)},
+	mDimensions{static_cast<vec2<T2>>(rect.mDimensions)},
+	mHorizontalAlign{rect.mHorizontalAlign},
+	mVerticalAlign{rect.mVerticalAlign}
+{
+	// Initialization done.
 }
+
+template<typename T>
+Rectangle<T>::Rectangle(const Rectangle<T>& rect, HorizontalAlign hAlign, VerticalAlign vAlign)
+:
+	Rectangle<T>{rect}
+{
+	changeAlign(hAlign, vAlign);
+}
+
+template<typename T>
+Rectangle<T>::Rectangle(const vec2<T>& position, const vec2<T>& dimensions, HorizontalAlign hAlign,
+                                                                            VerticalAlign vAlign)
+:
+	mPos{position},
+	mDimensions{dimensions},
+	mHorizontalAlign{hAlign},
+	mVerticalAlign{vAlign}
+{
+	// Initialization done.
+}
+
+template<typename T>
+Rectangle<T>::Rectangle(const vec2<T>& position, T width, T height, HorizontalAlign hAlign,
+                                                                    VerticalAlign vAlign)
+:
+	mPos{position},
+	mDimensions{width, height},
+	mHorizontalAlign{hAlign},
+	mVerticalAlign{vAlign}
+{
+	// Initialization done.
+}
+
+template<typename T>
+Rectangle<T>::Rectangle(T x, T y, T width, T height, HorizontalAlign hAlign, VerticalAlign vAlign)
+:
+	mPos{x, y},
+	mDimensions{width, height},
+	mHorizontalAlign{hAlign},
+	mVerticalAlign{vAlign}
+{
+	// Initialization done.
+}
+
+// Public member functions
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+bool Rectangle<T>::overlap(const vec2<T>& point) const
+{
+	Rectangle<T> leftBottomAlignRect{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
+
+	T rectXLeft = leftBottomAlignRect.x();
+	T rectXRight = rectXLeft + leftBottomAlignRect.width();
+	T rectYBottom = leftBottomAlignRect.y();
+	T rectYTop = rectYBottom + leftBottomAlignRect.height();
+	T vecX = point[0];
+	T vecY = point[1];
+
+	return rectXLeft <= vecX && rectXRight >= vecX &&
+	       rectYBottom <= vecY && rectYTop>= vecY;
+}
+
+template<typename T>
+bool Rectangle<T>::overlap(const Rectangle<T>& rect) const
+{
+	Rectangle<T> leftBottomAlignRectThis{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
+	Rectangle<T> leftBottomAlignRectOther{rect, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
+
+	T thisXLeft = leftBottomAlignRectThis.x();
+	T thisXRight = thisXLeft + leftBottomAlignRectThis.width();
+	T thisYBottom = leftBottomAlignRectThis.y();
+	T thisYTop = thisYBottom + leftBottomAlignRectThis.height();
+
+	T otherXLeft = leftBottomAlignRectOther.x();
+	T otherXRight = otherXLeft + leftBottomAlignRectOther.width();
+	T otherYBottom = leftBottomAlignRectOther.y();
+	T otherYTop = otherYBottom + leftBottomAlignRectOther.height();
+
+	return thisXLeft   <= otherXRight &&
+	       thisXRight  >= otherXLeft &&
+	       thisYBottom <= otherYTop &&
+	       thisYTop    >= otherYBottom;
+}
+
+template<typename T>
+bool Rectangle<T>::overlap(const Circle<T>& circle) const
+{
+	Rectangle<T> leftBottomAlignRect{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
+	Circle<T> centerAlignCircle{circle, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
+
+	T rectXLeft = leftBottomAlignRect.x();
+	T rectXRight = rectXLeft + leftBottomAlignRect.width();
+	T rectYBottom = leftBottomAlignRect.y();
+	T rectYTop = rectYBottom + leftBottomAlignRect.height();
+
+	T circleX = centerAlignCircle.x();
+	T circleY = centerAlignCircle.y();
+	T radius = centerAlignCircle.mRadius;
+
+	// If the length between the center of the circle and the closest point on the rectangle is
+	// less than or equal to the circles radius they overlap. Both sides of the equation is 
+	// squared to avoid somewhat expensive sqrt() function. 
+	T closestX = circleX;
+	T closestY = circleY;
+	
+	if (circleX <= rectXLeft) {
+		closestX = rectXLeft;
+	} 
+	else if (circleX >= rectXRight) {
+		closestX = rectXRight;
+	}
+	
+	if (circleY <= rectYBottom) {
+		closestY = rectYBottom;
+	}
+	else if (circleY >= rectYTop) {
+		closestY = rectYTop;
+	}
+	
+	return centerAlignCircle.mPos.distance(sfz::vec2<T>{closestX, closestY}).squaredNorm() 
+	       <= radius*radius;
+}
+
+template<typename T>
+T Rectangle<T>::area() const
+{
+	return width()*height();
+}
+
+template<typename T>
+T Rectangle<T>::circumference() const
+{
+	return width()*2 + height()*2;
+}
+
+template<typename T>
+size_t Rectangle<T>::hash() const
+{
+	std::hash<T> hasher;
+	std::hash<char> enumHasher;
+	size_t hash = 0;
+	// hash_combine algorithm from boost
+	hash ^= hasher(mPos[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= hasher(mPos[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= hasher(mDimensions[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= hasher(mDimensions[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= enumHasher(static_cast<char>(mHorizontalAlign)) +
+	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= enumHasher(static_cast<char>(mVerticalAlign)) +
+	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
+	return hash;
+}
+
+template<typename T>
+std::string Rectangle<T>::to_string() const
+{
+	std::string str;
+	str += "[pos=";
+	str += mPos.to_string();
+	str += ", dim=";
+	str += mDimensions.to_string();
+	str += ", align: ";
+	str += sfz::to_string(mHorizontalAlign);
+	str += ", ";
+	str += sfz::to_string(mVerticalAlign);
+	str += "]";
+	return std::move(str);
+}
+
+template<typename T>
+void Rectangle<T>::changeHorizontalAlign(HorizontalAlign hAlign)
+{
+	mPos[0] = calculateNewPosition(mPos[0], std::abs(mDimensions[0]), mHorizontalAlign, hAlign);
+	mHorizontalAlign = hAlign;
+}
+
+template<typename T>
+void Rectangle<T>::changeVerticalAlign(VerticalAlign vAlign)
+{
+	mPos[1] = calculateNewPosition(mPos[1], std::abs(mDimensions[1]), mVerticalAlign, vAlign);
+	mVerticalAlign = vAlign;
+}
+
+template<typename T>
+void Rectangle<T>::changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign)
+{
+	changeHorizontalAlign(hAlign);
+	changeVerticalAlign(vAlign);
+}
+
+// Getters
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+T Rectangle<T>::x() const
+{
+	return mPos[0];
+}
+
+template<typename T>
+T Rectangle<T>::y() const
+{
+	return mPos[1];
+}
+
+template<typename T>
+T Rectangle<T>::width() const
+{
+	return mDimensions[0];
+}
+
+template<typename T>
+T Rectangle<T>::height() const
+{
+	return mDimensions[1];
+}
+
+// Comparison operators
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+bool Rectangle<T>::operator== (const Rectangle<T>& other) const
+{
+	return mPos == other.mPos &&
+	       mDimensions == other.mDimensions &&
+	       mHorizontalAlign == other.mHorizontalAlign &&
+	       mVerticalAlign == other.mVerticalAlign;
+}
+
+template<typename T>
+bool Rectangle<T>::operator!= (const Rectangle<T>& other) const
+{
+	return !((*this) == other);
+}
+
+template<typename T>
+bool Rectangle<T>::operator< (const Rectangle<T>& other) const
+{
+	return this->area() < other.area();
+}
+
+template<typename T>
+bool Rectangle<T>::operator> (const Rectangle<T>& other) const
+{
+	return this->area() > other.area();
+}
+
+template<typename T>
+bool Rectangle<T>::operator<= (const Rectangle<T>& other) const
+{
+	return this->area() <= other.area();
+}
+
+template<typename T>
+bool Rectangle<T>::operator>= (const Rectangle<T>& other) const
+{
+	return this->area() >= other.area();
+}
+
+// Free (non-member) operators
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+template<typename T>
+std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect)
+{
+	return ostream << rect.to_string();
+}
+
+} // namespace sfz
 
 // Specializations of standard library for sfz::Rectangle
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 namespace std {
-	template<typename T>
-	size_t hash<sfz::Rectangle<T>>::operator() (const sfz::Rectangle<T>& rect) const {
-		return rect.hash();
-	}
+
+template<typename T>
+size_t hash<sfz::Rectangle<T>>::operator() (const sfz::Rectangle<T>& rect) const
+{
+	return rect.hash();
 }
+
+} // namespace std

--- a/include/sfz/math/Rectangle.inl
+++ b/include/sfz/math/Rectangle.inl
@@ -1,6 +1,6 @@
 namespace sfz {
 
-// Static constants
+// Static constants & public members
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
@@ -14,7 +14,7 @@ const VerticalAlign Rectangle<T>::s_DEFAULT_VERTICAL_ALIGN = VerticalAlign::MIDD
 
 template<typename T>
 template<typename T2>
-Rectangle<T>::Rectangle(const Rectangle<T2>& rect)
+Rectangle<T>::Rectangle(const Rectangle<T2>& rect) noexcept
 :
 	mPos{static_cast<vec2<T2>>(rect.mPos)},
 	mDimensions{static_cast<vec2<T2>>(rect.mDimensions)},
@@ -25,7 +25,8 @@ Rectangle<T>::Rectangle(const Rectangle<T2>& rect)
 }
 
 template<typename T>
-Rectangle<T>::Rectangle(const Rectangle<T>& rect, HorizontalAlign hAlign, VerticalAlign vAlign)
+Rectangle<T>::Rectangle(const Rectangle<T>& rect,
+                        HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	Rectangle<T>{rect}
 {
@@ -33,8 +34,8 @@ Rectangle<T>::Rectangle(const Rectangle<T>& rect, HorizontalAlign hAlign, Vertic
 }
 
 template<typename T>
-Rectangle<T>::Rectangle(const vec2<T>& position, const vec2<T>& dimensions, HorizontalAlign hAlign,
-                                                                            VerticalAlign vAlign)
+Rectangle<T>::Rectangle(const vec2<T>& position, const vec2<T>& dimensions,
+                        HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{position},
 	mDimensions{dimensions},
@@ -45,8 +46,8 @@ Rectangle<T>::Rectangle(const vec2<T>& position, const vec2<T>& dimensions, Hori
 }
 
 template<typename T>
-Rectangle<T>::Rectangle(const vec2<T>& position, T width, T height, HorizontalAlign hAlign,
-                                                                    VerticalAlign vAlign)
+Rectangle<T>::Rectangle(const vec2<T>& position, T width, T height, 
+                        HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{position},
 	mDimensions{width, height},
@@ -57,7 +58,8 @@ Rectangle<T>::Rectangle(const vec2<T>& position, T width, T height, HorizontalAl
 }
 
 template<typename T>
-Rectangle<T>::Rectangle(T x, T y, T width, T height, HorizontalAlign hAlign, VerticalAlign vAlign)
+Rectangle<T>::Rectangle(T x, T y, T width, T height,
+                        HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{x, y},
 	mDimensions{width, height},
@@ -71,14 +73,14 @@ Rectangle<T>::Rectangle(T x, T y, T width, T height, HorizontalAlign hAlign, Ver
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
-bool Rectangle<T>::overlap(const vec2<T>& point) const
+bool Rectangle<T>::overlap(const vec2<T>& point) const noexcept
 {
 	Rectangle<T> leftBottomAlignRect{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
 
 	T rectXLeft = leftBottomAlignRect.x();
-	T rectXRight = rectXLeft + leftBottomAlignRect.width();
+	T rectXRight = rectXLeft + std::abs(leftBottomAlignRect.width());
 	T rectYBottom = leftBottomAlignRect.y();
-	T rectYTop = rectYBottom + leftBottomAlignRect.height();
+	T rectYTop = rectYBottom + std::abs(leftBottomAlignRect.height());
 	T vecX = point[0];
 	T vecY = point[1];
 
@@ -87,20 +89,20 @@ bool Rectangle<T>::overlap(const vec2<T>& point) const
 }
 
 template<typename T>
-bool Rectangle<T>::overlap(const Rectangle<T>& rect) const
+bool Rectangle<T>::overlap(const Rectangle<T>& rect) const noexcept
 {
 	Rectangle<T> leftBottomAlignRectThis{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
 	Rectangle<T> leftBottomAlignRectOther{rect, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
 
 	T thisXLeft = leftBottomAlignRectThis.x();
-	T thisXRight = thisXLeft + leftBottomAlignRectThis.width();
+	T thisXRight = thisXLeft + std::abs(leftBottomAlignRectThis.width());
 	T thisYBottom = leftBottomAlignRectThis.y();
-	T thisYTop = thisYBottom + leftBottomAlignRectThis.height();
+	T thisYTop = thisYBottom + std::abs(leftBottomAlignRectThis.height());
 
 	T otherXLeft = leftBottomAlignRectOther.x();
-	T otherXRight = otherXLeft + leftBottomAlignRectOther.width();
+	T otherXRight = otherXLeft + std::abs(leftBottomAlignRectOther.width());
 	T otherYBottom = leftBottomAlignRectOther.y();
-	T otherYTop = otherYBottom + leftBottomAlignRectOther.height();
+	T otherYTop = otherYBottom + std::abs(leftBottomAlignRectOther.height());
 
 	return thisXLeft   <= otherXRight &&
 	       thisXRight  >= otherXLeft &&
@@ -109,19 +111,19 @@ bool Rectangle<T>::overlap(const Rectangle<T>& rect) const
 }
 
 template<typename T>
-bool Rectangle<T>::overlap(const Circle<T>& circle) const
+bool Rectangle<T>::overlap(const Circle<T>& circle) const noexcept
 {
 	Rectangle<T> leftBottomAlignRect{*this, HorizontalAlign::LEFT, VerticalAlign::BOTTOM};
 	Circle<T> centerAlignCircle{circle, HorizontalAlign::CENTER, VerticalAlign::MIDDLE};
 
 	T rectXLeft = leftBottomAlignRect.x();
-	T rectXRight = rectXLeft + leftBottomAlignRect.width();
+	T rectXRight = rectXLeft + std::abs(leftBottomAlignRect.width());
 	T rectYBottom = leftBottomAlignRect.y();
-	T rectYTop = rectYBottom + leftBottomAlignRect.height();
+	T rectYTop = rectYBottom + std::abs(leftBottomAlignRect.height());
 
 	T circleX = centerAlignCircle.x();
 	T circleY = centerAlignCircle.y();
-	T radius = centerAlignCircle.mRadius;
+	T radius = std::abs(centerAlignCircle.mRadius);
 
 	// If the length between the center of the circle and the closest point on the rectangle is
 	// less than or equal to the circles radius they overlap. Both sides of the equation is 
@@ -148,19 +150,19 @@ bool Rectangle<T>::overlap(const Circle<T>& circle) const
 }
 
 template<typename T>
-T Rectangle<T>::area() const
+T Rectangle<T>::area() const noexcept
 {
-	return width()*height();
+	return std::abs(width())*std::abs(height());
 }
 
 template<typename T>
-T Rectangle<T>::circumference() const
+T Rectangle<T>::circumference() const noexcept
 {
-	return width()*2 + height()*2;
+	return std::abs(width())*2 + std::abs(height())*2;
 }
 
 template<typename T>
-size_t Rectangle<T>::hash() const
+size_t Rectangle<T>::hash() const noexcept
 {
 	std::hash<T> hasher;
 	std::hash<char> enumHasher;
@@ -178,7 +180,7 @@ size_t Rectangle<T>::hash() const
 }
 
 template<typename T>
-std::string Rectangle<T>::to_string() const
+std::string Rectangle<T>::to_string() const noexcept
 {
 	std::string str;
 	str += "[pos=";
@@ -194,21 +196,21 @@ std::string Rectangle<T>::to_string() const
 }
 
 template<typename T>
-void Rectangle<T>::changeHorizontalAlign(HorizontalAlign hAlign)
+void Rectangle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 {
 	mPos[0] = calculateNewPosition(mPos[0], std::abs(mDimensions[0]), mHorizontalAlign, hAlign);
 	mHorizontalAlign = hAlign;
 }
 
 template<typename T>
-void Rectangle<T>::changeVerticalAlign(VerticalAlign vAlign)
+void Rectangle<T>::changeVerticalAlign(VerticalAlign vAlign) noexcept
 {
 	mPos[1] = calculateNewPosition(mPos[1], std::abs(mDimensions[1]), mVerticalAlign, vAlign);
 	mVerticalAlign = vAlign;
 }
 
 template<typename T>
-void Rectangle<T>::changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign)
+void Rectangle<T>::changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 {
 	changeHorizontalAlign(hAlign);
 	changeVerticalAlign(vAlign);
@@ -218,25 +220,25 @@ void Rectangle<T>::changeAlign(HorizontalAlign hAlign, VerticalAlign vAlign)
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
-T Rectangle<T>::x() const
+T Rectangle<T>::x() const noexcept
 {
 	return mPos[0];
 }
 
 template<typename T>
-T Rectangle<T>::y() const
+T Rectangle<T>::y() const noexcept
 {
 	return mPos[1];
 }
 
 template<typename T>
-T Rectangle<T>::width() const
+T Rectangle<T>::width() const noexcept
 {
 	return mDimensions[0];
 }
 
 template<typename T>
-T Rectangle<T>::height() const
+T Rectangle<T>::height() const noexcept
 {
 	return mDimensions[1];
 }
@@ -245,7 +247,7 @@ T Rectangle<T>::height() const
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
-bool Rectangle<T>::operator== (const Rectangle<T>& other) const
+bool Rectangle<T>::operator== (const Rectangle<T>& other) const noexcept
 {
 	return mPos == other.mPos &&
 	       mDimensions == other.mDimensions &&
@@ -254,31 +256,31 @@ bool Rectangle<T>::operator== (const Rectangle<T>& other) const
 }
 
 template<typename T>
-bool Rectangle<T>::operator!= (const Rectangle<T>& other) const
+bool Rectangle<T>::operator!= (const Rectangle<T>& other) const noexcept
 {
 	return !((*this) == other);
 }
 
 template<typename T>
-bool Rectangle<T>::operator< (const Rectangle<T>& other) const
+bool Rectangle<T>::operator< (const Rectangle<T>& other) const noexcept
 {
 	return this->area() < other.area();
 }
 
 template<typename T>
-bool Rectangle<T>::operator> (const Rectangle<T>& other) const
+bool Rectangle<T>::operator> (const Rectangle<T>& other) const noexcept
 {
 	return this->area() > other.area();
 }
 
 template<typename T>
-bool Rectangle<T>::operator<= (const Rectangle<T>& other) const
+bool Rectangle<T>::operator<= (const Rectangle<T>& other) const noexcept
 {
 	return this->area() <= other.area();
 }
 
 template<typename T>
-bool Rectangle<T>::operator>= (const Rectangle<T>& other) const
+bool Rectangle<T>::operator>= (const Rectangle<T>& other) const noexcept
 {
 	return this->area() >= other.area();
 }
@@ -287,7 +289,7 @@ bool Rectangle<T>::operator>= (const Rectangle<T>& other) const
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 template<typename T>
-std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect)
+std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect) noexcept
 {
 	return ostream << rect.to_string();
 }
@@ -299,7 +301,7 @@ std::ostream& operator<< (std::ostream& ostream, const Rectangle<T> rect)
 namespace std {
 
 template<typename T>
-size_t hash<sfz::Rectangle<T>>::operator() (const sfz::Rectangle<T>& rect) const
+size_t hash<sfz::Rectangle<T>>::operator() (const sfz::Rectangle<T>& rect) const noexcept
 {
 	return rect.hash();
 }

--- a/include/sfz/math/Rectangle.inl
+++ b/include/sfz/math/Rectangle.inl
@@ -108,9 +108,9 @@ namespace sfz {
 		T rectYBottom = leftBottomAlignRect.getY();
 		T rectYTop = rectYBottom + leftBottomAlignRect.getHeight();
 
-		T circleX = centerAlignCircle.getX();
-		T circleY = centerAlignCircle.getY();
-		T radius = centerAlignCircle.getRadius();
+		T circleX = centerAlignCircle.x();
+		T circleY = centerAlignCircle.y();
+		T radius = centerAlignCircle.mRadius;
 
 		// If the length between the center of the circle and the closest point on the rectangle is less than or equal
 		// to the circles radius they overlap. Both sides of the equation is squared to avoid expensive sqrt() 
@@ -132,7 +132,7 @@ namespace sfz {
 			closestY = rectYTop;
 		}
 		
-		return centerAlignCircle.getPosition().distance(sfz::vec2<T>{closestX, closestY}).squaredNorm() 
+		return centerAlignCircle.mPos.distance(sfz::vec2<T>{closestX, closestY}).squaredNorm() 
 		       <= radius*radius;
 	}
 

--- a/include/sfz/math/Rectangle.inl
+++ b/include/sfz/math/Rectangle.inl
@@ -198,6 +198,9 @@ std::string Rectangle<T>::to_string() const noexcept
 template<typename T>
 void Rectangle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 {
+	assert(mHorizontalAlign == HorizontalAlign::LEFT ||
+	       mHorizontalAlign == HorizontalAlign::CENTER ||
+	       mHorizontalAlign == HorizontalAlign::RIGHT);
 	mPos[0] = calculateNewPosition(mPos[0], std::abs(mDimensions[0]), mHorizontalAlign, hAlign);
 	mHorizontalAlign = hAlign;
 }
@@ -205,6 +208,9 @@ void Rectangle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 template<typename T>
 void Rectangle<T>::changeVerticalAlign(VerticalAlign vAlign) noexcept
 {
+	assert(mVerticalAlign == VerticalAlign::BOTTOM ||
+	       mVerticalAlign == VerticalAlign::MIDDLE ||
+	       mVerticalAlign == VerticalAlign::TOP);
 	mPos[1] = calculateNewPosition(mPos[1], std::abs(mDimensions[1]), mVerticalAlign, vAlign);
 	mVerticalAlign = vAlign;
 }

--- a/include/sfz/math/Vector.inl
+++ b/include/sfz/math/Vector.inl
@@ -271,7 +271,7 @@ T angle(const Vector<T,2>& vector) noexcept
 	assert(!(vector[0] == 0 && vector[1] == 0));
 	T angle = std::atan2(vector[1], vector[0]);
 	if (angle < 0) {
-		angle += static_cast<T>(2)*static_cast<T>(PI_DOUBLE);
+		angle += static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE);
 	}
 	return angle;
 }

--- a/test/sfz/math/Circle_Tests.cpp
+++ b/test/sfz/math/Circle_Tests.cpp
@@ -1,7 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
-#include <stdexcept>
 #include <vector>
 #include <unordered_map>
 #include "sfz/math/Circle.hpp"

--- a/test/sfz/math/Circle_Tests.cpp
+++ b/test/sfz/math/Circle_Tests.cpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <type_traits>
 #include "sfz/math/Circle.hpp"
 
 TEST_CASE("Constructors", "[sfz::Circle]")
@@ -295,4 +296,32 @@ TEST_CASE("to_string()", "[sfz::Circle]")
 {
 	sfz::Circle<int> c{1, 2, 3, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::TOP};
 	REQUIRE(c.to_string() == "[pos=[1, 2], r=3, align: LEFT, TOP]");
+}
+
+TEST_CASE("Is proper POD", "[sfz::Circle]")
+{
+	REQUIRE(std::is_trivially_default_constructible<sfz::circf>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::circd>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::circi>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::circl>::value);
+
+	REQUIRE(std::is_trivially_copyable<sfz::circf>::value);
+	REQUIRE(std::is_trivially_copyable<sfz::circd>::value);
+	REQUIRE(std::is_trivially_copyable<sfz::circi>::value);
+	REQUIRE(std::is_trivially_copyable<sfz::circl>::value);
+
+	REQUIRE(std::is_trivial<sfz::circf>::value);
+	REQUIRE(std::is_trivial<sfz::circd>::value);
+	REQUIRE(std::is_trivial<sfz::circi>::value);
+	REQUIRE(std::is_trivial<sfz::circl>::value);
+
+	REQUIRE(std::is_standard_layout<sfz::circf>::value);
+	REQUIRE(std::is_standard_layout<sfz::circd>::value);
+	REQUIRE(std::is_standard_layout<sfz::circi>::value);
+	REQUIRE(std::is_standard_layout<sfz::circl>::value);
+
+	REQUIRE(std::is_pod<sfz::circf>::value);
+	REQUIRE(std::is_pod<sfz::circd>::value);
+	REQUIRE(std::is_pod<sfz::circi>::value);
+	REQUIRE(std::is_pod<sfz::circl>::value);
 }

--- a/test/sfz/math/Circle_Tests.cpp
+++ b/test/sfz/math/Circle_Tests.cpp
@@ -41,12 +41,6 @@ TEST_CASE("Constructors", "[sfz::Circle]")
 		REQUIRE(circ.mRadius == 2);
 		REQUIRE(circ.mHorizontalAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
 		REQUIRE(circ.mVerticalAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-		try {
-			sfz::Circle<int>{sfz::vec2i{0, 0}, -1};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
 	}
 	SECTION("(x, y, radius) constructor") {
 		sfz::Circle<int> circ{-1, 2, 2};
@@ -55,12 +49,6 @@ TEST_CASE("Constructors", "[sfz::Circle]")
 		REQUIRE(circ.mRadius == 2);
 		REQUIRE(circ.mHorizontalAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
 		REQUIRE(circ.mVerticalAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-		try {
-			sfz::Circle<int>{0, 0, -1};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
 	}
 }
 

--- a/test/sfz/math/Circle_Tests.cpp
+++ b/test/sfz/math/Circle_Tests.cpp
@@ -38,8 +38,8 @@ TEST_CASE("Constructors", "[sfz::Circle]") {
 		REQUIRE(circ.getX() == -1);
 		REQUIRE(circ.getY() == 2);
 		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 		try {
 			sfz::Circle<int>{sfz::vec2i{0, 0}, -1};
 			REQUIRE(false);
@@ -52,8 +52,8 @@ TEST_CASE("Constructors", "[sfz::Circle]") {
 		REQUIRE(circ.getX() == -1);
 		REQUIRE(circ.getY() == 2);
 		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 		try {
 			sfz::Circle<int>{0, 0, -1};
 			REQUIRE(false);
@@ -203,8 +203,8 @@ TEST_CASE("Getters", "[sfz::Circle]") {
 	SECTION("getHorizontalAlign() & getVerticalAlign()") {
 		REQUIRE(circ1.getHorizontalAlign() == sfz::HorizontalAlign::LEFT);
 		REQUIRE(circ1.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
-		REQUIRE(circ2.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ2.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ2.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ2.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 }
 
@@ -216,16 +216,16 @@ TEST_CASE("Setters", "[sfz::Circle]") {
 		REQUIRE(circ.getX() == -1);
 		REQUIRE(circ.getY() == 3);
 		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("setPosition(x,y)") {
 		circ.setPosition(9, 1);
 		REQUIRE(circ.getX() == 9);
 		REQUIRE(circ.getY() == 1);
 		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("setX() & setY()") {
 		circ.setX(44);
@@ -233,29 +233,29 @@ TEST_CASE("Setters", "[sfz::Circle]") {
 		REQUIRE(circ.getX() == 44);
 		REQUIRE(circ.getY() == -220);
 		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("setRadius()") {
 		circ.setRadius(5);
 		REQUIRE(circ.getX() == 0);
 		REQUIRE(circ.getY() == 0);
 		REQUIRE(circ.getRadius() == 5);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 		REQUIRE_THROWS_AS(circ.setRadius(-1), std::invalid_argument);
 	}
 	SECTION("setHorizontalAlign() & setVerticalAlign()") {
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 		circ.setHorizontalAlign(sfz::HorizontalAlign::RIGHT);
 		circ.setVerticalAlign(sfz::VerticalAlign::BOTTOM);
 		REQUIRE(circ.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
 		REQUIRE(circ.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
 	}
 	SECTION("changeHorizontalAlign()") {
-		REQUIRE(sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
-		REQUIRE(sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
+		REQUIRE(sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
 
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::LEFT);
 		REQUIRE(circ.getX() == -2);
@@ -268,8 +268,8 @@ TEST_CASE("Setters", "[sfz::Circle]") {
 		REQUIRE(circ.getHorizontalAlign() == sfz::HorizontalAlign::CENTER);
 	}
 	SECTION("changeVerticalAlign()") {
-		REQUIRE(sfz::Circle<int>::DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
-		REQUIRE(sfz::Circle<int>::DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
+		REQUIRE(sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
 
 		circ.changeVerticalAlign(sfz::VerticalAlign::TOP);
 		REQUIRE(circ.getY() == 2);
@@ -354,8 +354,8 @@ TEST_CASE("Hashing", "[sfz::Circle]") {
 		REQUIRE(r2.hash() != r3.hash());
 	}
 	SECTION("Hash map") {
-		// This test checks if unordered_map works as it should. Not a very good test, but the best I can come up with
-		// to test if hashing works as it should at the moment.
+		// This test checks if unordered_map works as it should. Not a very good test, but the best
+		// I can come up with to test if hashing works as it should at the moment.
 		std::unordered_map<sfz::Circle<int>, int> hashMap;
 		hashMap[r1] = 1;
 		hashMap[r2] = 2;

--- a/test/sfz/math/Circle_Tests.cpp
+++ b/test/sfz/math/Circle_Tests.cpp
@@ -6,40 +6,41 @@
 #include <unordered_map>
 #include "sfz/math/Circle.hpp"
 
-TEST_CASE("Constructors", "[sfz::Circle]") {
+TEST_CASE("Constructors", "[sfz::Circle]")
+{
 	SECTION("Copy constructor") {
 		sfz::Circle<int> circ1{1, 2, 3, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
 		sfz::Circle<int> circ2{circ1};
-		REQUIRE(circ1.getPosition() == circ2.getPosition());
-		REQUIRE(circ1.getRadius() == circ2.getRadius());
-		REQUIRE(circ1.getHorizontalAlign() == circ2.getHorizontalAlign());
-		REQUIRE(circ1.getVerticalAlign() == circ2.getVerticalAlign());
+		REQUIRE(circ1.mPos == circ2.mPos);
+		REQUIRE(circ1.mRadius == circ2.mRadius);
+		REQUIRE(circ1.mHorizontalAlign == circ2.mHorizontalAlign);
+		REQUIRE(circ1.mVerticalAlign == circ2.mVerticalAlign);
 	}
 	SECTION("Copy cast constructor") {
 		sfz::Circle<float> circlef{1.1f, 2.2f, 3.3f};
 		sfz::Circle<int> circlei{circlef};
-		REQUIRE(circlei.getX() == 1);
-		REQUIRE(circlei.getY() == 2);
-		REQUIRE(circlei.getRadius() == 3);
-		REQUIRE(circlei.getHorizontalAlign() == circlef.getHorizontalAlign());
-		REQUIRE(circlei.getVerticalAlign() == circlef.getVerticalAlign());
+		REQUIRE(circlei.x() == 1);
+		REQUIRE(circlei.y() == 2);
+		REQUIRE(circlei.mRadius == 3);
+		REQUIRE(circlei.mHorizontalAlign == circlef.mHorizontalAlign);
+		REQUIRE(circlei.mVerticalAlign == circlef.mVerticalAlign);
 	}
 	SECTION("Copy constructor with alignment change") {
 		sfz::Circle<int> circ1{0, 0, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
 		sfz::Circle<int> circ2{circ1, sfz::HorizontalAlign::RIGHT, sfz::VerticalAlign::TOP};
-		REQUIRE(circ2.getX() == 2);
-		REQUIRE(circ2.getY() == 2);
-		REQUIRE(circ2.getRadius() == circ1.getRadius());
-		REQUIRE(circ2.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
-		REQUIRE(circ2.getVerticalAlign() == sfz::VerticalAlign::TOP);
+		REQUIRE(circ2.x() == 2);
+		REQUIRE(circ2.y() == 2);
+		REQUIRE(circ2.mRadius == circ1.mRadius);
+		REQUIRE(circ2.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(circ2.mVerticalAlign == sfz::VerticalAlign::TOP);
 	}
 	SECTION("(vec2, radius) constructor") {
 		sfz::Circle<int> circ{sfz::vec2i{-1, 2}, 2};
-		REQUIRE(circ.getX() == -1);
-		REQUIRE(circ.getY() == 2);
-		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.x() == -1);
+		REQUIRE(circ.y() == 2);
+		REQUIRE(circ.mRadius == 2);
+		REQUIRE(circ.mHorizontalAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.mVerticalAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 		try {
 			sfz::Circle<int>{sfz::vec2i{0, 0}, -1};
 			REQUIRE(false);
@@ -49,11 +50,11 @@ TEST_CASE("Constructors", "[sfz::Circle]") {
 	}
 	SECTION("(x, y, radius) constructor") {
 		sfz::Circle<int> circ{-1, 2, 2};
-		REQUIRE(circ.getX() == -1);
-		REQUIRE(circ.getY() == 2);
-		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.x() == -1);
+		REQUIRE(circ.y() == 2);
+		REQUIRE(circ.mRadius == 2);
+		REQUIRE(circ.mHorizontalAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.mVerticalAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 		try {
 			sfz::Circle<int>{0, 0, -1};
 			REQUIRE(false);
@@ -63,7 +64,8 @@ TEST_CASE("Constructors", "[sfz::Circle]") {
 	}
 }
 
-TEST_CASE("Overlap tests", "[sfz::Circle]") {
+TEST_CASE("Overlap tests", "[sfz::Circle]")
+{
 	sfz::Circle<int> circ{1, 1, 1};
 
 	SECTION("overlap(vec2)") {
@@ -146,10 +148,14 @@ TEST_CASE("Overlap tests", "[sfz::Circle]") {
 	SECTION("overlap(Rectangle)") {
 		std::vector<sfz::Rectangle<int>> overlapping;
 		overlapping.emplace_back(1, 1, 2, 2);
-		overlapping.emplace_back(0, 0, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
-		overlapping.emplace_back(0, 1, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
-		overlapping.emplace_back(1, 0, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
-		overlapping.emplace_back(1, 1, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
+		overlapping.emplace_back(0, 0, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                     sfz::VerticalAlign::BOTTOM);
+		overlapping.emplace_back(0, 1, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                     sfz::VerticalAlign::BOTTOM);
+		overlapping.emplace_back(1, 0, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                     sfz::VerticalAlign::BOTTOM);
+		overlapping.emplace_back(1, 1, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                     sfz::VerticalAlign::BOTTOM);
 		overlapping.emplace_back(1, 1, 8, 8);
 
 		std::vector<sfz::Rectangle<int>> nonOverlapping;
@@ -180,110 +186,40 @@ TEST_CASE("Overlap tests", "[sfz::Circle]") {
 	}
 }
 
-TEST_CASE("Getters", "[sfz::Circle]") {
-	const sfz::Circle<int> circ1{1, 2, 3, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
-	const sfz::Circle<int> circ2{3, 2, 1};
-
-	SECTION("getPosition()") {
-		REQUIRE(circ1.getPosition()[0] == 1);
-		REQUIRE(circ1.getPosition()[1] == 2);
-		REQUIRE(circ2.getPosition()[0] == 3);
-		REQUIRE(circ2.getPosition()[1] == 2);
-	}
-	SECTION("getX() & getY()") {
-		REQUIRE(circ1.getX() == 1);
-		REQUIRE(circ1.getY() == 2);
-		REQUIRE(circ2.getX() == 3);
-		REQUIRE(circ2.getY() == 2);
-	}
-	SECTION("getRadius()") {
-		REQUIRE(circ1.getRadius() == 3);
-		REQUIRE(circ2.getRadius() == 1);
-	}
-	SECTION("getHorizontalAlign() & getVerticalAlign()") {
-		REQUIRE(circ1.getHorizontalAlign() == sfz::HorizontalAlign::LEFT);
-		REQUIRE(circ1.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
-		REQUIRE(circ2.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ2.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-	}
-}
-
 TEST_CASE("Setters", "[sfz::Circle]") {
 	sfz::Circle<int> circ{0, 0, 2};
-
-	SECTION("setPosition(vec2)") {
-		circ.setPosition(sfz::vec2i{-1, 3});
-		REQUIRE(circ.getX() == -1);
-		REQUIRE(circ.getY() == 3);
-		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-	}
-	SECTION("setPosition(x,y)") {
-		circ.setPosition(9, 1);
-		REQUIRE(circ.getX() == 9);
-		REQUIRE(circ.getY() == 1);
-		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-	}
-	SECTION("setX() & setY()") {
-		circ.setX(44);
-		circ.setY(-220);
-		REQUIRE(circ.getX() == 44);
-		REQUIRE(circ.getY() == -220);
-		REQUIRE(circ.getRadius() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-	}
-	SECTION("setRadius()") {
-		circ.setRadius(5);
-		REQUIRE(circ.getX() == 0);
-		REQUIRE(circ.getY() == 0);
-		REQUIRE(circ.getRadius() == 5);
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-		REQUIRE_THROWS_AS(circ.setRadius(-1), std::invalid_argument);
-	}
-	SECTION("setHorizontalAlign() & setVerticalAlign()") {
-		REQUIRE(circ.getHorizontalAlign() == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.getVerticalAlign() == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
-		circ.setHorizontalAlign(sfz::HorizontalAlign::RIGHT);
-		circ.setVerticalAlign(sfz::VerticalAlign::BOTTOM);
-		REQUIRE(circ.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
-		REQUIRE(circ.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
-	}
 	SECTION("changeHorizontalAlign()") {
 		REQUIRE(sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
 		REQUIRE(sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
 
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::LEFT);
-		REQUIRE(circ.getX() == -2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::HorizontalAlign::LEFT);
+		REQUIRE(circ.x() == -2);
+		REQUIRE(circ.mHorizontalAlign == sfz::HorizontalAlign::LEFT);
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::RIGHT);
-		REQUIRE(circ.getX() == 2);
-		REQUIRE(circ.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(circ.x() == 2);
+		REQUIRE(circ.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::CENTER);
-		REQUIRE(circ.getX() == 0);
-		REQUIRE(circ.getHorizontalAlign() == sfz::HorizontalAlign::CENTER);
+		REQUIRE(circ.x() == 0);
+		REQUIRE(circ.mHorizontalAlign == sfz::HorizontalAlign::CENTER);
 	}
 	SECTION("changeVerticalAlign()") {
 		REQUIRE(sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
 		REQUIRE(sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
 
 		circ.changeVerticalAlign(sfz::VerticalAlign::TOP);
-		REQUIRE(circ.getY() == 2);
-		REQUIRE(circ.getVerticalAlign() == sfz::VerticalAlign::TOP);
+		REQUIRE(circ.y() == 2);
+		REQUIRE(circ.mVerticalAlign == sfz::VerticalAlign::TOP);
 		circ.changeVerticalAlign(sfz::VerticalAlign::BOTTOM);
-		REQUIRE(circ.getY() == -2);
-		REQUIRE(circ.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
+		REQUIRE(circ.y() == -2);
+		REQUIRE(circ.mVerticalAlign == sfz::VerticalAlign::BOTTOM);
 		circ.changeVerticalAlign(sfz::VerticalAlign::MIDDLE);
-		REQUIRE(circ.getY() == 0);
-		REQUIRE(circ.getVerticalAlign() == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(circ.y() == 0);
+		REQUIRE(circ.mVerticalAlign == sfz::VerticalAlign::MIDDLE);
 	}
 }
 
-TEST_CASE("Area and circumference", "[sfz::Circle]") {
+TEST_CASE("Area and circumference", "[sfz::Circle]")
+{
 	sfz::Circle<int> r1{0, 0, 10};
 	sfz::Circle<int> r2{0, 0, 1};
 	SECTION("area()") {
@@ -296,7 +232,8 @@ TEST_CASE("Area and circumference", "[sfz::Circle]") {
 	}
 }
 
-TEST_CASE("Comparison operators", "[sfz::Circle]") {
+TEST_CASE("Comparison operators", "[sfz::Circle]")
+{
 	sfz::Circle<int> r1{0, 0, 10};
 	sfz::Circle<int> r2{0, 0, 10};
 	sfz::Circle<int> r3{0, 0, 1};
@@ -344,7 +281,8 @@ TEST_CASE("Comparison operators", "[sfz::Circle]") {
 	}
 }
 
-TEST_CASE("Hashing", "[sfz::Circle]") {
+TEST_CASE("Hashing", "[sfz::Circle]")
+{
 	sfz::Circle<int> r1{-1, 100, 32};
 	sfz::Circle<int> r2{-1, 100, 32, sfz::HorizontalAlign::RIGHT, sfz::VerticalAlign::TOP};
 	sfz::Circle<int> r3{0, -9, 2};
@@ -366,7 +304,8 @@ TEST_CASE("Hashing", "[sfz::Circle]") {
 	}
 }
 
-TEST_CASE("to_string()", "[sfz::Circle]") {
+TEST_CASE("to_string()", "[sfz::Circle]")
+{
 	sfz::Circle<int> c{1, 2, 3, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::TOP};
 	REQUIRE(c.to_string() == "[pos=[1, 2], r=3, align: LEFT, TOP]");
 }

--- a/test/sfz/math/MathConstants_Tests.cpp
+++ b/test/sfz/math/MathConstants_Tests.cpp
@@ -3,13 +3,14 @@
 
 #include "sfz/math/MathConstants.hpp"
 
-TEST_CASE("Pi constants", "[MathConstants]") {
+TEST_CASE("Pi constants", "[MathConstants]")
+{
 	SECTION("Float version") {
-		REQUIRE(3.1415f <= sfz::PI_FLOAT);
-		REQUIRE(sfz::PI_FLOAT <= 3.1416f);
+		REQUIRE(3.1415f <= sfz::g_PI_FLOAT);
+		REQUIRE(sfz::g_PI_FLOAT <= 3.1416f);
 	}
 	SECTION("Double version") {
-		REQUIRE(3.1415 <= sfz::PI_DOUBLE);
-		REQUIRE(sfz::PI_DOUBLE <= 3.1416);
+		REQUIRE(3.1415 <= sfz::g_PI_DOUBLE);
+		REQUIRE(sfz::g_PI_DOUBLE <= 3.1416);
 	}
 }

--- a/test/sfz/math/Rectangle_Tests.cpp
+++ b/test/sfz/math/Rectangle_Tests.cpp
@@ -1,107 +1,71 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
-#include <stdexcept>
 #include <vector>
 #include <unordered_map>
-#include "sfz/math/Vector.hpp"
 #include "sfz/math/Rectangle.hpp"
-#include "sfz/math/Circle.hpp"
 
-TEST_CASE("Constructors", "[sfz::Rectangle]") {
+TEST_CASE("Constructors", "[sfz::Rectangle]")
+{
 	SECTION("Copy constructor") {
 		sfz::Rectangle<int> rect1{1, 2, 3, 4, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::TOP};
 		sfz::Rectangle<int> rect2{rect1};
-		REQUIRE(rect1.getPosition() == rect2.getPosition());
-		REQUIRE(rect1.getDimensions() == rect2.getDimensions());
-		REQUIRE(rect1.getHorizontalAlign() == rect2.getHorizontalAlign());
-		REQUIRE(rect1.getVerticalAlign() == rect2.getVerticalAlign());
+		REQUIRE(rect1.mPos == rect2.mPos);
+		REQUIRE(rect1.mDimensions == rect2.mDimensions);
+		REQUIRE(rect1.mHorizontalAlign == rect2.mHorizontalAlign);
+		REQUIRE(rect1.mVerticalAlign == rect2.mVerticalAlign);
 	}
 	SECTION("Copy cast constructor") {
 		sfz::Rectangle<float> rectf{1.1f, 2.2f, 3.3f, 4.4f};
 		sfz::Rectangle<int> recti{rectf};
-		REQUIRE(recti.getX() == 1);
-		REQUIRE(recti.getY() == 2);
-		REQUIRE(recti.getWidth() == 3);
-		REQUIRE(recti.getHeight() == 4);
-		REQUIRE(recti.getHorizontalAlign() == rectf.getHorizontalAlign());
-		REQUIRE(recti.getVerticalAlign() == rectf.getVerticalAlign());
+		REQUIRE(recti.x() == 1);
+		REQUIRE(recti.y() == 2);
+		REQUIRE(recti.width() == 3);
+		REQUIRE(recti.height() == 4);
+		REQUIRE(recti.mHorizontalAlign == rectf.mHorizontalAlign);
+		REQUIRE(recti.mVerticalAlign == rectf.mVerticalAlign);
 	}
 	SECTION("Copy constructor with alignment change") {
-		sfz::Rectangle<int> rect1{0, 0, 2, 2, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
+		sfz::Rectangle<int> rect1{0, 0, 2, 2, sfz::HorizontalAlign::LEFT,
+		                                      sfz::VerticalAlign::BOTTOM};
 		sfz::Rectangle<int> rect2{rect1, sfz::HorizontalAlign::RIGHT, sfz::VerticalAlign::TOP};
-		REQUIRE(rect2.getX() == 2);
-		REQUIRE(rect2.getY() == 2);
-		REQUIRE(rect2.getDimensions() == rect1.getDimensions());
-		REQUIRE(rect2.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
-		REQUIRE(rect2.getVerticalAlign() == sfz::VerticalAlign::TOP);
+		REQUIRE(rect2.x() == 2);
+		REQUIRE(rect2.y() == 2);
+		REQUIRE(rect2.mDimensions == rect1.mDimensions);
+		REQUIRE(rect2.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(rect2.mVerticalAlign == sfz::VerticalAlign::TOP);
 	}
 	SECTION("(vec2 position, vec2 dimensions) constructor") {
 		sfz::Rectangle<int> rect{sfz::vec2i{1, 2}, sfz::vec2i{3, 4}};
-		REQUIRE(rect.getX() == 1);
-		REQUIRE(rect.getY() == 2);
-		REQUIRE(rect.getWidth() == 3);
-		REQUIRE(rect.getHeight() == 4);
-		REQUIRE(rect.getHorizontalAlign() == sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.getVerticalAlign() == sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN);
-		try {
-			sfz::Rectangle<int>{sfz::vec2i{0, 0}, sfz::vec2i{-1, 0}};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
-		try {
-			sfz::Rectangle<int>{sfz::vec2i{0, 0}, sfz::vec2i{0, -1}};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
+		REQUIRE(rect.x() == 1);
+		REQUIRE(rect.y() == 2);
+		REQUIRE(rect.width() == 3);
+		REQUIRE(rect.height() == 4);
+		REQUIRE(rect.mHorizontalAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(rect.mVerticalAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("(vec2 position, width, height) constructor") {
 		sfz::Rectangle<int> rect{sfz::vec2i{1, 2}, 3, 4};
-		REQUIRE(rect.getX() == 1);
-		REQUIRE(rect.getY() == 2);
-		REQUIRE(rect.getWidth() == 3);
-		REQUIRE(rect.getHeight() == 4);
-		REQUIRE(rect.getHorizontalAlign() == sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.getVerticalAlign() == sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN);
-		try {
-			sfz::Rectangle<int>{sfz::vec2i{0, 0}, -1, 0};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
-		try {
-			sfz::Rectangle<int>{sfz::vec2i{0, 0}, 0, -1};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
+		REQUIRE(rect.x() == 1);
+		REQUIRE(rect.y() == 2);
+		REQUIRE(rect.width() == 3);
+		REQUIRE(rect.height() == 4);
+		REQUIRE(rect.mHorizontalAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(rect.mVerticalAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("(x, y, width, height) constructor") {
 		sfz::Rectangle<int> rect{1, 2, 3, 4};
-		REQUIRE(rect.getX() == 1);
-		REQUIRE(rect.getY() == 2);
-		REQUIRE(rect.getWidth() == 3);
-		REQUIRE(rect.getHeight() == 4);
-		REQUIRE(rect.getHorizontalAlign() == sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.getVerticalAlign() == sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN);
-		try {
-			sfz::Rectangle<int>{0, 0, -1, 0};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
-		try {
-			sfz::Rectangle<int>{0, 0, 0, -1};
-			REQUIRE(false);
-		} catch (std::invalid_argument e) {
-			REQUIRE(true);
-		}
+		REQUIRE(rect.x() == 1);
+		REQUIRE(rect.y() == 2);
+		REQUIRE(rect.width() == 3);
+		REQUIRE(rect.height() == 4);
+		REQUIRE(rect.mHorizontalAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(rect.mVerticalAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 }
 
-TEST_CASE("Overlap tests", "[sfz::Rectangle]") {
+TEST_CASE("Overlap tests", "[sfz::Rectangle]")
+{
 	sfz::Rectangle<int> rect{0, 0, 2, 2, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
 	
 	SECTION("overlap(vec2)") {
@@ -151,10 +115,14 @@ TEST_CASE("Overlap tests", "[sfz::Rectangle]") {
 	SECTION("overlap(Rectangle)") {
 		std::vector<sfz::Rectangle<int>> overlappingRects;
 		overlappingRects.emplace_back(1, 1, 2, 2);
-		overlappingRects.emplace_back(0, 0, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
-		overlappingRects.emplace_back(0, 1, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
-		overlappingRects.emplace_back(1, 0, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
-		overlappingRects.emplace_back(1, 1, 1, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM);
+		overlappingRects.emplace_back(0, 0, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                          sfz::VerticalAlign::BOTTOM);
+		overlappingRects.emplace_back(0, 1, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                          sfz::VerticalAlign::BOTTOM);
+		overlappingRects.emplace_back(1, 0, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                          sfz::VerticalAlign::BOTTOM);
+		overlappingRects.emplace_back(1, 1, 1, 1, sfz::HorizontalAlign::LEFT,
+		                                          sfz::VerticalAlign::BOTTOM);
 		overlappingRects.emplace_back(1, 1, 8, 8);
 
 		std::vector<sfz::Rectangle<int>> nonOverlappingRects;
@@ -220,134 +188,62 @@ TEST_CASE("Overlap tests", "[sfz::Rectangle]") {
 	}
 }
 
-TEST_CASE("Getters", "[sfz::Rectangle]") {
-	const sfz::Rectangle<int> rect1{1, 2, 3, 4, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
+TEST_CASE("Getters", "[sfz::Rectangle]")
+{
+	const sfz::Rectangle<int> rect1{1, 2, 3, 4, sfz::HorizontalAlign::LEFT,
+	                                            sfz::VerticalAlign::BOTTOM};
 	const sfz::Rectangle<int> rect2{4, 3, 2, 1};
 
-	SECTION("getPosition()") {
-		REQUIRE(rect1.getPosition()[0] == 1);
-		REQUIRE(rect1.getPosition()[1] == 2);
-		REQUIRE(rect2.getPosition()[0] == 4);
-		REQUIRE(rect2.getPosition()[1] == 3);
+	SECTION("x() & y()") {
+		REQUIRE(rect1.x() == 1);
+		REQUIRE(rect1.y() == 2);
+		REQUIRE(rect2.x() == 4);
+		REQUIRE(rect2.y() == 3);
 	}
-	SECTION("getX() & getY()") {
-		REQUIRE(rect1.getX() == 1);
-		REQUIRE(rect1.getY() == 2);
-		REQUIRE(rect2.getX() == 4);
-		REQUIRE(rect2.getY() == 3);
-	}
-	SECTION("getDimensions()") {
-		REQUIRE(rect1.getDimensions()[0] == 3);
-		REQUIRE(rect1.getDimensions()[1] == 4);
-		REQUIRE(rect2.getDimensions()[0] == 2);
-		REQUIRE(rect2.getDimensions()[1] == 1);
-	}
-	SECTION("getWidth() & getHeight()") {
-		REQUIRE(rect1.getWidth() == 3);
-		REQUIRE(rect1.getHeight() == 4);
-		REQUIRE(rect2.getWidth() == 2);
-		REQUIRE(rect2.getHeight() == 1);
-	}
-	SECTION("getHorizontalAlign() & getVerticalAlign()") {
-		REQUIRE(rect1.getHorizontalAlign() == sfz::HorizontalAlign::LEFT);
-		REQUIRE(rect1.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
-		REQUIRE(rect2.getHorizontalAlign() == sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect2.getVerticalAlign() == sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN);
+	SECTION("width() & height()") {
+		REQUIRE(rect1.width() == 3);
+		REQUIRE(rect1.height() == 4);
+		REQUIRE(rect2.width() == 2);
+		REQUIRE(rect2.height() == 1);
 	}
 }
 
-TEST_CASE("Setters", "[sfz::Rectangle]") {
+TEST_CASE("Setters", "[sfz::Rectangle]")
+{
 	sfz::Rectangle<int> rect{0, 0, 2, 2};
 
-	SECTION("setPosition(vec2)") {
-		rect.setPosition(sfz::vec2i{-1, 3});
-		REQUIRE(rect.getX() == -1);
-		REQUIRE(rect.getY() == 3);
-		REQUIRE(rect.getWidth() == 2);
-		REQUIRE(rect.getHeight() == 2);
-	}
-	SECTION("setPosition(x,y)") {
-		rect.setPosition(9, 1);
-		REQUIRE(rect.getX() == 9);
-		REQUIRE(rect.getY() == 1);
-		REQUIRE(rect.getWidth() == 2);
-		REQUIRE(rect.getHeight() == 2);
-	}
-	SECTION("setX() & setY()") {
-		rect.setX(44);
-		rect.setY(-220);
-		REQUIRE(rect.getX() == 44);
-		REQUIRE(rect.getY() == -220);
-		REQUIRE(rect.getWidth() == 2);
-		REQUIRE(rect.getHeight() == 2);
-	}
-	SECTION("setDimensions(vec2)") {
-		rect.setDimensions(sfz::vec2i{4, 2});
-		REQUIRE(rect.getX() == 0);
-		REQUIRE(rect.getY() == 0);
-		REQUIRE(rect.getWidth() == 4);
-		REQUIRE(rect.getHeight() == 2);
-		REQUIRE_THROWS_AS(rect.setDimensions(sfz::vec2i{-1, 0}), std::invalid_argument);
-		REQUIRE_THROWS_AS(rect.setDimensions(sfz::vec2i{0, -1}), std::invalid_argument);
-	}
-	SECTION("setDimensions(x,y)") {
-		rect.setDimensions(42, 21);
-		REQUIRE(rect.getX() == 0);
-		REQUIRE(rect.getY() == 0);
-		REQUIRE(rect.getWidth() == 42);
-		REQUIRE(rect.getHeight() == 21);
-		REQUIRE_THROWS_AS(rect.setDimensions(-1, 0), std::invalid_argument);
-		REQUIRE_THROWS_AS(rect.setDimensions(0, -1), std::invalid_argument);
-	}
-	SECTION("setWidth() & setHeight()") {
-		rect.setWidth(5);
-		rect.setHeight(55);
-		REQUIRE(rect.getX() == 0);
-		REQUIRE(rect.getY() == 0);
-		REQUIRE(rect.getWidth() == 5);
-		REQUIRE(rect.getHeight() == 55);
-		REQUIRE_THROWS_AS(rect.setWidth(-1), std::invalid_argument);
-		REQUIRE_THROWS_AS(rect.setHeight(-2), std::invalid_argument);
-	}
-	SECTION("setHorizontalAlign() & setVerticalAlign()") {
-		REQUIRE(rect.getHorizontalAlign() == sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.getVerticalAlign() == sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN);
-		rect.setHorizontalAlign(sfz::HorizontalAlign::RIGHT);
-		rect.setVerticalAlign(sfz::VerticalAlign::BOTTOM);
-		REQUIRE(rect.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
-		REQUIRE(rect.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
-	}
 	SECTION("changeHorizontalAlign()") {
-		REQUIRE(sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
-		REQUIRE(sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
+		REQUIRE(sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
 
 		rect.changeHorizontalAlign(sfz::HorizontalAlign::LEFT);
-		REQUIRE(rect.getX() == -1);
-		REQUIRE(rect.getHorizontalAlign() == sfz::HorizontalAlign::LEFT);
+		REQUIRE(rect.x() == -1);
+		REQUIRE(rect.mHorizontalAlign == sfz::HorizontalAlign::LEFT);
 		rect.changeHorizontalAlign(sfz::HorizontalAlign::RIGHT);
-		REQUIRE(rect.getX() == 1);
-		REQUIRE(rect.getHorizontalAlign() == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(rect.x() == 1);
+		REQUIRE(rect.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
 		rect.changeHorizontalAlign(sfz::HorizontalAlign::CENTER);
-		REQUIRE(rect.getX() == 0);
-		REQUIRE(rect.getHorizontalAlign() == sfz::HorizontalAlign::CENTER);
+		REQUIRE(rect.x() == 0);
+		REQUIRE(rect.mHorizontalAlign == sfz::HorizontalAlign::CENTER);
 	}
 	SECTION("changeVerticalAlign()") {
-		REQUIRE(sfz::Rectangle<int>::DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
-		REQUIRE(sfz::Rectangle<int>::DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
+		REQUIRE(sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN == sfz::VerticalAlign::MIDDLE);
 
 		rect.changeVerticalAlign(sfz::VerticalAlign::TOP);
-		REQUIRE(rect.getY() == 1);
-		REQUIRE(rect.getVerticalAlign() == sfz::VerticalAlign::TOP);
+		REQUIRE(rect.y() == 1);
+		REQUIRE(rect.mVerticalAlign == sfz::VerticalAlign::TOP);
 		rect.changeVerticalAlign(sfz::VerticalAlign::BOTTOM);
-		REQUIRE(rect.getY() == -1);
-		REQUIRE(rect.getVerticalAlign() == sfz::VerticalAlign::BOTTOM);
+		REQUIRE(rect.y() == -1);
+		REQUIRE(rect.mVerticalAlign == sfz::VerticalAlign::BOTTOM);
 		rect.changeVerticalAlign(sfz::VerticalAlign::MIDDLE);
-		REQUIRE(rect.getY() == 0);
-		REQUIRE(rect.getVerticalAlign() == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(rect.y() == 0);
+		REQUIRE(rect.mVerticalAlign == sfz::VerticalAlign::MIDDLE);
 	}
 }
 
-TEST_CASE("Area and circumference", "[sfz::Rectangle]") {
+TEST_CASE("Area and circumference", "[sfz::Rectangle]")
+{
 	sfz::Rectangle<int> r1{0, 0, 10, 10};
 	sfz::Rectangle<int> r2{0, 0, 1, 10};
 	SECTION("area()") {
@@ -360,7 +256,8 @@ TEST_CASE("Area and circumference", "[sfz::Rectangle]") {
 	}
 }
 
-TEST_CASE("Comparison operators", "[sfz::Rectangle]") {
+TEST_CASE("Comparison operators", "[sfz::Rectangle]")
+{
 	sfz::Rectangle<int> r1{0, 0, 10, 10};
 	sfz::Rectangle<int> r2{0, 0, 10, 10};
 	sfz::Rectangle<int> r3{0, 0, 1, 10};
@@ -408,7 +305,8 @@ TEST_CASE("Comparison operators", "[sfz::Rectangle]") {
 	}
 }
 
-TEST_CASE("Hashing", "[sfz::Rectangle]") {
+TEST_CASE("Hashing", "[sfz::Rectangle]")
+{
 	sfz::Rectangle<int> r1{-1, 100, 32, 32};
 	sfz::Rectangle<int> r2{-1, 100, 32, 32, sfz::HorizontalAlign::RIGHT, sfz::VerticalAlign::TOP};
 	sfz::Rectangle<int> r3{0, -9, 14, 2};
@@ -418,8 +316,8 @@ TEST_CASE("Hashing", "[sfz::Rectangle]") {
 		REQUIRE(r2.hash() != r3.hash());
 	}
 	SECTION("Hash map") {
-		// This test checks if unordered_map works as it should. Not a very good test, but the best I can come up with
-		// to test if hashing works as it should at the moment.
+		// This test checks if unordered_map works as it should. Not a very good test, but the best
+		// I can come up with to test if hashing works as it should at the moment.
 		std::unordered_map<sfz::Rectangle<int>, int> hashMap;
 		hashMap[r1] = 1;
 		hashMap[r2] = 2;
@@ -430,7 +328,8 @@ TEST_CASE("Hashing", "[sfz::Rectangle]") {
 	}
 }
 
-TEST_CASE("to_string()", "[sfz::Rectangle]") {
+TEST_CASE("to_string()", "[sfz::Rectangle]")
+{
 	sfz::Rectangle<int> r{1, 2, 3, 4, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::TOP};
 	REQUIRE(r.to_string() == "[pos=[1, 2], dim=[3, 4], align: LEFT, TOP]");
 }

--- a/test/sfz/math/Rectangle_Tests.cpp
+++ b/test/sfz/math/Rectangle_Tests.cpp
@@ -333,3 +333,31 @@ TEST_CASE("to_string()", "[sfz::Rectangle]")
 	sfz::Rectangle<int> r{1, 2, 3, 4, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::TOP};
 	REQUIRE(r.to_string() == "[pos=[1, 2], dim=[3, 4], align: LEFT, TOP]");
 }
+
+TEST_CASE("Is proper POD", "[sfz::Rectangle]")
+{
+	REQUIRE(std::is_trivially_default_constructible<sfz::rectf>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::rectd>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::recti>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::rectl>::value);
+
+	REQUIRE(std::is_trivially_copyable<sfz::rectf>::value);
+	REQUIRE(std::is_trivially_copyable<sfz::rectd>::value);
+	REQUIRE(std::is_trivially_copyable<sfz::recti>::value);
+	REQUIRE(std::is_trivially_copyable<sfz::rectl>::value);
+
+	REQUIRE(std::is_trivial<sfz::rectf>::value);
+	REQUIRE(std::is_trivial<sfz::rectd>::value);
+	REQUIRE(std::is_trivial<sfz::recti>::value);
+	REQUIRE(std::is_trivial<sfz::rectl>::value);
+
+	REQUIRE(std::is_standard_layout<sfz::rectf>::value);
+	REQUIRE(std::is_standard_layout<sfz::rectd>::value);
+	REQUIRE(std::is_standard_layout<sfz::recti>::value);
+	REQUIRE(std::is_standard_layout<sfz::rectl>::value);
+
+	REQUIRE(std::is_pod<sfz::rectf>::value);
+	REQUIRE(std::is_pod<sfz::rectd>::value);
+	REQUIRE(std::is_pod<sfz::recti>::value);
+	REQUIRE(std::is_pod<sfz::rectl>::value);
+}

--- a/test/sfz/math/Vector_Tests.cpp
+++ b/test/sfz/math/Vector_Tests.cpp
@@ -480,6 +480,15 @@ TEST_CASE("Hashing", "[sfz::Vector]")
 
 TEST_CASE("Is proper POD", "[sfz::Vector]")
 {
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec2f>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec2d>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec2i>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec2l>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec3f>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec3d>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec3i>::value);
+	REQUIRE(std::is_trivially_default_constructible<sfz::vec3l>::value);
+
 	REQUIRE(std::is_trivially_copyable<sfz::vec2f>::value);
 	REQUIRE(std::is_trivially_copyable<sfz::vec2d>::value);
 	REQUIRE(std::is_trivially_copyable<sfz::vec2i>::value);


### PR DESCRIPTION
- Fixed syntax to follow new coding standards
- Removed exceptions, use assert instead. Marked all functions noexcept.
- Made members public and  removed getters & setters from Circle & Rectangle.
- Removed restriction preventing widths and radiuses from being negative.
- Made Circle & Rectangle into POD classes.
