### PR TITLE
Shortens names of public members in Rectangle & Circle

### DIFF
--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -47,9 +47,9 @@ public:
 	 * @brief [0] -> x-pos, [1] -> y-pos
 	 */
 	vec2<T> mPos;
-	T mRadius;
-	HorizontalAlign mHorizontalAlign;
-	VerticalAlign mVerticalAlign;
+	T mRad;
+	HorizontalAlign mHAlign;
+	VerticalAlign mVAlign;
 
 	// Constructors and destructors
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -162,8 +162,8 @@ public:
 	/**
 	 * @brief Changes the HorizontalAlign and updates the position to reflect this.
 	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
-	 * shifted. If this is not wanted mHorizontalAlign should be set directly.
-	 * @assert mHorizontalAlign has a valid alignment
+	 * shifted. If this is not wanted mHAlign should be set directly.
+	 * @assert mHAlign has a valid alignment
 	 * @param hAlign the HorizontalAlign to set
 	 */
 	void changeHorizontalAlign(HorizontalAlign hAlign) noexcept;
@@ -171,8 +171,8 @@ public:
 	/**
 	 * @brief Changes the VerticalAlign and updates the position to reflect this.
 	 * The position is updated so the Circle's actual position is the same afterwards, i.e. not
-	 * shifted. If this is not wanted mVerticalAlign should be set directly.
-	 * @assert mVerticalAlign has a valid alignment
+	 * shifted. If this is not wanted mVAlign should be set directly.
+	 * @assert mVAlign has a valid alignment
 	 * @param vAlign the VerticalAlign to set
 	 */
 	void changeVerticalAlign(VerticalAlign vAlign) noexcept;

--- a/include/sfz/math/Circle.hpp
+++ b/include/sfz/math/Circle.hpp
@@ -199,6 +199,11 @@ public:
 	 */
 	T y() const noexcept;
 
+	/**
+	 * @return radius of this Circle.
+	 */
+	T radius() const noexcept;
+
 	// Comparison operators
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -176,6 +176,12 @@ T Circle<T>::y() const noexcept
 	return mPos[1];
 }
 
+template<typename T>
+T Circle<T>::radius() const noexcept
+{
+	return mRadius;
+}
+
 // Comparison operators
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 

--- a/include/sfz/math/Circle.inl
+++ b/include/sfz/math/Circle.inl
@@ -17,10 +17,10 @@ template<typename T2>
 Circle<T>::Circle(const Circle<T2>& circle) noexcept
 :
 	mPos{static_cast<vec2<T2>>(circle.mPos)},
-	mHorizontalAlign{circle.mHorizontalAlign},
-	mVerticalAlign{circle.mVerticalAlign}
+	mHAlign{circle.mHAlign},
+	mVAlign{circle.mVAlign}
 {
-	mRadius = static_cast<T2>(circle.mRadius);
+	mRad = static_cast<T2>(circle.mRad);
 }
 
 
@@ -37,9 +37,9 @@ template<typename T>
 Circle<T>::Circle(vec2<T> position, T radius, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{position},
-	mRadius{radius},
-	mHorizontalAlign{hAlign},
-	mVerticalAlign{vAlign}
+	mRad{radius},
+	mHAlign{hAlign},
+	mVAlign{vAlign}
 {
 	// Initialization done.
 }
@@ -48,9 +48,9 @@ template<typename T>
 Circle<T>::Circle(T x, T y, T radius, HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{x, y},
-	mRadius{radius},
-	mHorizontalAlign{hAlign},
-	mVerticalAlign{vAlign}
+	mRad{radius},
+	mHAlign{hAlign},
+	mVAlign{vAlign}
 {
 	// Initialization done.
 }
@@ -66,7 +66,7 @@ bool Circle<T>::overlap(const vec2<T>& point) const noexcept
 	// If the length from this circles center to the specified point is shorter than or equal to
 	// the radius then this Circle overlaps the point. Both sides of the equation is squared to
 	// avoid somewhat expensive sqrt() function.
-	return centerAlignCircle.mPos.distance(point).squaredNorm() <= mRadius*mRadius;
+	return centerAlignCircle.mPos.distance(point).squaredNorm() <= mRad*mRad;
 }
 
 template<typename T>
@@ -79,7 +79,7 @@ bool Circle<T>::overlap(const Circle<T>& circle) const noexcept
 	// the circle's radiuses they overlap. Both sides of the equation is squared to avoid somewhat 
 	// expensive sqrt() function.
 	T distSquared = centerAlignCircleThis.mPos.distance(centerAlignCircleOther.mPos).squaredNorm();
-	T radiusSum = std::abs(centerAlignCircleThis.mRadius) + std::abs(centerAlignCircleOther.mRadius);
+	T radiusSum = std::abs(centerAlignCircleThis.mRad) + std::abs(centerAlignCircleOther.mRad);
 	return distSquared <= radiusSum * radiusSum;
 }
 
@@ -92,13 +92,13 @@ bool Circle<T>::overlap(const Rectangle<T>& rect) const noexcept
 template<typename T>
 T Circle<T>::area() const noexcept
 {
-	return static_cast<T>(g_PI_DOUBLE)*mRadius*mRadius;
+	return static_cast<T>(g_PI_DOUBLE)*mRad*mRad;
 }
 
 template<typename T>
 T Circle<T>::circumference() const noexcept
 {
-	return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*std::abs(mRadius);
+	return static_cast<T>(2)*static_cast<T>(g_PI_DOUBLE)*std::abs(mRad);
 }
 
 template<typename T>
@@ -110,10 +110,10 @@ size_t Circle<T>::hash() const noexcept
 	// hash_combine algorithm from boost
 	hash ^= hasher(mPos[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 	hash ^= hasher(mPos[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= hasher(mRadius) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= enumHasher(static_cast<char>(mHorizontalAlign)) +
+	hash ^= hasher(mRad) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= enumHasher(static_cast<char>(mHAlign)) +
 	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= enumHasher(static_cast<char>(mVerticalAlign)) + 
+	hash ^= enumHasher(static_cast<char>(mVAlign)) + 
 	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
 	return hash;
 }
@@ -125,11 +125,11 @@ std::string Circle<T>::to_string() const noexcept
 	str += "[pos=";
 	str += mPos.to_string();
 	str += ", r=";
-	str += std::to_string(mRadius);
+	str += std::to_string(mRad);
 	str += ", align: ";
-	str += sfz::to_string(mHorizontalAlign);
+	str += sfz::to_string(mHAlign);
 	str += ", ";
-	str += sfz::to_string(mVerticalAlign);
+	str += sfz::to_string(mVAlign);
 	str += "]";
 	return std::move(str);
 }
@@ -137,21 +137,21 @@ std::string Circle<T>::to_string() const noexcept
 template<typename T>
 void Circle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 {
-	assert(mHorizontalAlign == HorizontalAlign::LEFT ||
-	       mHorizontalAlign == HorizontalAlign::CENTER ||
-	       mHorizontalAlign == HorizontalAlign::RIGHT);
-	mPos[0] = calculateNewPosition(mPos[0], mRadius*2, mHorizontalAlign, hAlign);
-	mHorizontalAlign = hAlign;
+	assert(mHAlign == HorizontalAlign::LEFT ||
+	       mHAlign == HorizontalAlign::CENTER ||
+	       mHAlign == HorizontalAlign::RIGHT);
+	mPos[0] = calculateNewPosition(mPos[0], mRad*2, mHAlign, hAlign);
+	mHAlign = hAlign;
 }
 
 template<typename T>
 void Circle<T>::changeVerticalAlign(VerticalAlign vAlign) noexcept
 {
-	assert(mVerticalAlign == VerticalAlign::BOTTOM ||
-	       mVerticalAlign == VerticalAlign::MIDDLE ||
-	       mVerticalAlign == VerticalAlign::TOP);
-	mPos[1] = calculateNewPosition(mPos[1], mRadius*2, mVerticalAlign, vAlign);
-	mVerticalAlign = vAlign;
+	assert(mVAlign == VerticalAlign::BOTTOM ||
+	       mVAlign == VerticalAlign::MIDDLE ||
+	       mVAlign == VerticalAlign::TOP);
+	mPos[1] = calculateNewPosition(mPos[1], mRad*2, mVAlign, vAlign);
+	mVAlign = vAlign;
 }
 
 template<typename T>
@@ -179,7 +179,7 @@ T Circle<T>::y() const noexcept
 template<typename T>
 T Circle<T>::radius() const noexcept
 {
-	return mRadius;
+	return mRad;
 }
 
 // Comparison operators
@@ -189,9 +189,9 @@ template<typename T>
 bool Circle<T>::operator== (const Circle<T>& other) const noexcept
 {
 	return mPos == other.mPos &&
-	       mRadius == other.mRadius &&
-	       mHorizontalAlign == other.mHorizontalAlign &&
-	       mVerticalAlign == other.mVerticalAlign;
+	       mRad == other.mRad &&
+	       mHAlign == other.mHAlign &&
+	       mVAlign == other.mVAlign;
 }
 
 template<typename T>

--- a/include/sfz/math/Rectangle.hpp
+++ b/include/sfz/math/Rectangle.hpp
@@ -50,9 +50,9 @@ public:
 	/**
 	 * @brief [0] -> width, [1] -> height
 	 */
-	vec2<T> mDimensions;
-	HorizontalAlign mHorizontalAlign;
-	VerticalAlign mVerticalAlign;
+	vec2<T> mDim;
+	HorizontalAlign mHAlign;
+	VerticalAlign mVAlign;
 
 	// Constructors and destructors
 	// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -181,7 +181,7 @@ public:
 	/**
 	 * @brief Changes the HorizontalAlign of this Rectangle and updates the position.
 	 * The position is updated so the Rectangle's actual position is the same afterwards, i.e. not
-	 * shifted. If this is not wanted mHorizontalAlign should be set directly.
+	 * shifted. If this is not wanted mHAlign should be set directly.
 	 * Even if the width is negative this function will behave as if it's positive.
 	 * @param hAlign the HorizontalAlign to set
 	 */
@@ -190,7 +190,7 @@ public:
 	/**
 	 * @brief Changes the VerticalAlign of this Rectangle and updates the position.
 	 * The position is updated so the Rectangle's actual position is the same afterwards, i.e. not
-	 * shifted. If this is not wanted mVeritcalAlign should be set directly.
+	 * shifted. If this is not wanted mVAlign should be set directly.
 	 * Even if the height is negative this function will behave as if it's positive.
 	 * @param vAlign the VerticalAlign to set
 	 */

--- a/include/sfz/math/Rectangle.inl
+++ b/include/sfz/math/Rectangle.inl
@@ -17,9 +17,9 @@ template<typename T2>
 Rectangle<T>::Rectangle(const Rectangle<T2>& rect) noexcept
 :
 	mPos{static_cast<vec2<T2>>(rect.mPos)},
-	mDimensions{static_cast<vec2<T2>>(rect.mDimensions)},
-	mHorizontalAlign{rect.mHorizontalAlign},
-	mVerticalAlign{rect.mVerticalAlign}
+	mDim{static_cast<vec2<T2>>(rect.mDim)},
+	mHAlign{rect.mHAlign},
+	mVAlign{rect.mVAlign}
 {
 	// Initialization done.
 }
@@ -38,9 +38,9 @@ Rectangle<T>::Rectangle(const vec2<T>& position, const vec2<T>& dimensions,
                         HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{position},
-	mDimensions{dimensions},
-	mHorizontalAlign{hAlign},
-	mVerticalAlign{vAlign}
+	mDim{dimensions},
+	mHAlign{hAlign},
+	mVAlign{vAlign}
 {
 	// Initialization done.
 }
@@ -50,9 +50,9 @@ Rectangle<T>::Rectangle(const vec2<T>& position, T width, T height,
                         HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{position},
-	mDimensions{width, height},
-	mHorizontalAlign{hAlign},
-	mVerticalAlign{vAlign}
+	mDim{width, height},
+	mHAlign{hAlign},
+	mVAlign{vAlign}
 {
 	// Initialization done.
 }
@@ -62,9 +62,9 @@ Rectangle<T>::Rectangle(T x, T y, T width, T height,
                         HorizontalAlign hAlign, VerticalAlign vAlign) noexcept
 :
 	mPos{x, y},
-	mDimensions{width, height},
-	mHorizontalAlign{hAlign},
-	mVerticalAlign{vAlign}
+	mDim{width, height},
+	mHAlign{hAlign},
+	mVAlign{vAlign}
 {
 	// Initialization done.
 }
@@ -170,11 +170,11 @@ size_t Rectangle<T>::hash() const noexcept
 	// hash_combine algorithm from boost
 	hash ^= hasher(mPos[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 	hash ^= hasher(mPos[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= hasher(mDimensions[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= hasher(mDimensions[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= enumHasher(static_cast<char>(mHorizontalAlign)) +
+	hash ^= hasher(mDim[0]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= hasher(mDim[1]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+	hash ^= enumHasher(static_cast<char>(mHAlign)) +
 	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
-	hash ^= enumHasher(static_cast<char>(mVerticalAlign)) +
+	hash ^= enumHasher(static_cast<char>(mVAlign)) +
 	                   0x9e3779b9 + (hash << 6) + (hash >> 2);
 	return hash;
 }
@@ -186,11 +186,11 @@ std::string Rectangle<T>::to_string() const noexcept
 	str += "[pos=";
 	str += mPos.to_string();
 	str += ", dim=";
-	str += mDimensions.to_string();
+	str += mDim.to_string();
 	str += ", align: ";
-	str += sfz::to_string(mHorizontalAlign);
+	str += sfz::to_string(mHAlign);
 	str += ", ";
-	str += sfz::to_string(mVerticalAlign);
+	str += sfz::to_string(mVAlign);
 	str += "]";
 	return std::move(str);
 }
@@ -198,21 +198,21 @@ std::string Rectangle<T>::to_string() const noexcept
 template<typename T>
 void Rectangle<T>::changeHorizontalAlign(HorizontalAlign hAlign) noexcept
 {
-	assert(mHorizontalAlign == HorizontalAlign::LEFT ||
-	       mHorizontalAlign == HorizontalAlign::CENTER ||
-	       mHorizontalAlign == HorizontalAlign::RIGHT);
-	mPos[0] = calculateNewPosition(mPos[0], std::abs(mDimensions[0]), mHorizontalAlign, hAlign);
-	mHorizontalAlign = hAlign;
+	assert(mHAlign == HorizontalAlign::LEFT ||
+	       mHAlign == HorizontalAlign::CENTER ||
+	       mHAlign == HorizontalAlign::RIGHT);
+	mPos[0] = calculateNewPosition(mPos[0], std::abs(mDim[0]), mHAlign, hAlign);
+	mHAlign = hAlign;
 }
 
 template<typename T>
 void Rectangle<T>::changeVerticalAlign(VerticalAlign vAlign) noexcept
 {
-	assert(mVerticalAlign == VerticalAlign::BOTTOM ||
-	       mVerticalAlign == VerticalAlign::MIDDLE ||
-	       mVerticalAlign == VerticalAlign::TOP);
-	mPos[1] = calculateNewPosition(mPos[1], std::abs(mDimensions[1]), mVerticalAlign, vAlign);
-	mVerticalAlign = vAlign;
+	assert(mVAlign == VerticalAlign::BOTTOM ||
+	       mVAlign == VerticalAlign::MIDDLE ||
+	       mVAlign == VerticalAlign::TOP);
+	mPos[1] = calculateNewPosition(mPos[1], std::abs(mDim[1]), mVAlign, vAlign);
+	mVAlign = vAlign;
 }
 
 template<typename T>
@@ -240,13 +240,13 @@ T Rectangle<T>::y() const noexcept
 template<typename T>
 T Rectangle<T>::width() const noexcept
 {
-	return mDimensions[0];
+	return mDim[0];
 }
 
 template<typename T>
 T Rectangle<T>::height() const noexcept
 {
-	return mDimensions[1];
+	return mDim[1];
 }
 
 // Comparison operators
@@ -256,9 +256,9 @@ template<typename T>
 bool Rectangle<T>::operator== (const Rectangle<T>& other) const noexcept
 {
 	return mPos == other.mPos &&
-	       mDimensions == other.mDimensions &&
-	       mHorizontalAlign == other.mHorizontalAlign &&
-	       mVerticalAlign == other.mVerticalAlign;
+	       mDim == other.mDim &&
+	       mHAlign == other.mHAlign &&
+	       mVAlign == other.mVAlign;
 }
 
 template<typename T>

--- a/include/sfz/math/Rectangle.inl
+++ b/include/sfz/math/Rectangle.inl
@@ -123,7 +123,7 @@ bool Rectangle<T>::overlap(const Circle<T>& circle) const noexcept
 
 	T circleX = centerAlignCircle.x();
 	T circleY = centerAlignCircle.y();
-	T radius = std::abs(centerAlignCircle.mRadius);
+	T radius = std::abs(centerAlignCircle.radius());
 
 	// If the length between the center of the circle and the closest point on the rectangle is
 	// less than or equal to the circles radius they overlap. Both sides of the equation is 

--- a/test/sfz/math/Circle_Tests.cpp
+++ b/test/sfz/math/Circle_Tests.cpp
@@ -12,43 +12,43 @@ TEST_CASE("Constructors", "[sfz::Circle]")
 		sfz::Circle<int> circ1{1, 2, 3, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
 		sfz::Circle<int> circ2{circ1};
 		REQUIRE(circ1.mPos == circ2.mPos);
-		REQUIRE(circ1.mRadius == circ2.mRadius);
-		REQUIRE(circ1.mHorizontalAlign == circ2.mHorizontalAlign);
-		REQUIRE(circ1.mVerticalAlign == circ2.mVerticalAlign);
+		REQUIRE(circ1.mRad == circ2.mRad);
+		REQUIRE(circ1.mHAlign == circ2.mHAlign);
+		REQUIRE(circ1.mVAlign == circ2.mVAlign);
 	}
 	SECTION("Copy cast constructor") {
 		sfz::Circle<float> circlef{1.1f, 2.2f, 3.3f};
 		sfz::Circle<int> circlei{circlef};
 		REQUIRE(circlei.x() == 1);
 		REQUIRE(circlei.y() == 2);
-		REQUIRE(circlei.mRadius == 3);
-		REQUIRE(circlei.mHorizontalAlign == circlef.mHorizontalAlign);
-		REQUIRE(circlei.mVerticalAlign == circlef.mVerticalAlign);
+		REQUIRE(circlei.mRad == 3);
+		REQUIRE(circlei.mHAlign == circlef.mHAlign);
+		REQUIRE(circlei.mVAlign == circlef.mVAlign);
 	}
 	SECTION("Copy constructor with alignment change") {
 		sfz::Circle<int> circ1{0, 0, 1, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::BOTTOM};
 		sfz::Circle<int> circ2{circ1, sfz::HorizontalAlign::RIGHT, sfz::VerticalAlign::TOP};
 		REQUIRE(circ2.x() == 2);
 		REQUIRE(circ2.y() == 2);
-		REQUIRE(circ2.mRadius == circ1.mRadius);
-		REQUIRE(circ2.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
-		REQUIRE(circ2.mVerticalAlign == sfz::VerticalAlign::TOP);
+		REQUIRE(circ2.mRad == circ1.mRad);
+		REQUIRE(circ2.mHAlign == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(circ2.mVAlign == sfz::VerticalAlign::TOP);
 	}
 	SECTION("(vec2, radius) constructor") {
 		sfz::Circle<int> circ{sfz::vec2i{-1, 2}, 2};
 		REQUIRE(circ.x() == -1);
 		REQUIRE(circ.y() == 2);
-		REQUIRE(circ.mRadius == 2);
-		REQUIRE(circ.mHorizontalAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.mVerticalAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.mRad == 2);
+		REQUIRE(circ.mHAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.mVAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("(x, y, radius) constructor") {
 		sfz::Circle<int> circ{-1, 2, 2};
 		REQUIRE(circ.x() == -1);
 		REQUIRE(circ.y() == 2);
-		REQUIRE(circ.mRadius == 2);
-		REQUIRE(circ.mHorizontalAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(circ.mVerticalAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(circ.mRad == 2);
+		REQUIRE(circ.mHAlign == sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(circ.mVAlign == sfz::Circle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 }
 
@@ -182,13 +182,13 @@ TEST_CASE("Setters", "[sfz::Circle]") {
 
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::LEFT);
 		REQUIRE(circ.x() == -2);
-		REQUIRE(circ.mHorizontalAlign == sfz::HorizontalAlign::LEFT);
+		REQUIRE(circ.mHAlign == sfz::HorizontalAlign::LEFT);
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::RIGHT);
 		REQUIRE(circ.x() == 2);
-		REQUIRE(circ.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(circ.mHAlign == sfz::HorizontalAlign::RIGHT);
 		circ.changeHorizontalAlign(sfz::HorizontalAlign::CENTER);
 		REQUIRE(circ.x() == 0);
-		REQUIRE(circ.mHorizontalAlign == sfz::HorizontalAlign::CENTER);
+		REQUIRE(circ.mHAlign == sfz::HorizontalAlign::CENTER);
 	}
 	SECTION("changeVerticalAlign()") {
 		REQUIRE(sfz::Circle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
@@ -196,13 +196,13 @@ TEST_CASE("Setters", "[sfz::Circle]") {
 
 		circ.changeVerticalAlign(sfz::VerticalAlign::TOP);
 		REQUIRE(circ.y() == 2);
-		REQUIRE(circ.mVerticalAlign == sfz::VerticalAlign::TOP);
+		REQUIRE(circ.mVAlign == sfz::VerticalAlign::TOP);
 		circ.changeVerticalAlign(sfz::VerticalAlign::BOTTOM);
 		REQUIRE(circ.y() == -2);
-		REQUIRE(circ.mVerticalAlign == sfz::VerticalAlign::BOTTOM);
+		REQUIRE(circ.mVAlign == sfz::VerticalAlign::BOTTOM);
 		circ.changeVerticalAlign(sfz::VerticalAlign::MIDDLE);
 		REQUIRE(circ.y() == 0);
-		REQUIRE(circ.mVerticalAlign == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(circ.mVAlign == sfz::VerticalAlign::MIDDLE);
 	}
 }
 

--- a/test/sfz/math/Rectangle_Tests.cpp
+++ b/test/sfz/math/Rectangle_Tests.cpp
@@ -11,9 +11,9 @@ TEST_CASE("Constructors", "[sfz::Rectangle]")
 		sfz::Rectangle<int> rect1{1, 2, 3, 4, sfz::HorizontalAlign::LEFT, sfz::VerticalAlign::TOP};
 		sfz::Rectangle<int> rect2{rect1};
 		REQUIRE(rect1.mPos == rect2.mPos);
-		REQUIRE(rect1.mDimensions == rect2.mDimensions);
-		REQUIRE(rect1.mHorizontalAlign == rect2.mHorizontalAlign);
-		REQUIRE(rect1.mVerticalAlign == rect2.mVerticalAlign);
+		REQUIRE(rect1.mDim == rect2.mDim);
+		REQUIRE(rect1.mHAlign == rect2.mHAlign);
+		REQUIRE(rect1.mVAlign == rect2.mVAlign);
 	}
 	SECTION("Copy cast constructor") {
 		sfz::Rectangle<float> rectf{1.1f, 2.2f, 3.3f, 4.4f};
@@ -22,8 +22,8 @@ TEST_CASE("Constructors", "[sfz::Rectangle]")
 		REQUIRE(recti.y() == 2);
 		REQUIRE(recti.width() == 3);
 		REQUIRE(recti.height() == 4);
-		REQUIRE(recti.mHorizontalAlign == rectf.mHorizontalAlign);
-		REQUIRE(recti.mVerticalAlign == rectf.mVerticalAlign);
+		REQUIRE(recti.mHAlign == rectf.mHAlign);
+		REQUIRE(recti.mVAlign == rectf.mVAlign);
 	}
 	SECTION("Copy constructor with alignment change") {
 		sfz::Rectangle<int> rect1{0, 0, 2, 2, sfz::HorizontalAlign::LEFT,
@@ -31,9 +31,9 @@ TEST_CASE("Constructors", "[sfz::Rectangle]")
 		sfz::Rectangle<int> rect2{rect1, sfz::HorizontalAlign::RIGHT, sfz::VerticalAlign::TOP};
 		REQUIRE(rect2.x() == 2);
 		REQUIRE(rect2.y() == 2);
-		REQUIRE(rect2.mDimensions == rect1.mDimensions);
-		REQUIRE(rect2.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
-		REQUIRE(rect2.mVerticalAlign == sfz::VerticalAlign::TOP);
+		REQUIRE(rect2.mDim == rect1.mDim);
+		REQUIRE(rect2.mHAlign == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(rect2.mVAlign == sfz::VerticalAlign::TOP);
 	}
 	SECTION("(vec2 position, vec2 dimensions) constructor") {
 		sfz::Rectangle<int> rect{sfz::vec2i{1, 2}, sfz::vec2i{3, 4}};
@@ -41,8 +41,8 @@ TEST_CASE("Constructors", "[sfz::Rectangle]")
 		REQUIRE(rect.y() == 2);
 		REQUIRE(rect.width() == 3);
 		REQUIRE(rect.height() == 4);
-		REQUIRE(rect.mHorizontalAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.mVerticalAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(rect.mHAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(rect.mVAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("(vec2 position, width, height) constructor") {
 		sfz::Rectangle<int> rect{sfz::vec2i{1, 2}, 3, 4};
@@ -50,8 +50,8 @@ TEST_CASE("Constructors", "[sfz::Rectangle]")
 		REQUIRE(rect.y() == 2);
 		REQUIRE(rect.width() == 3);
 		REQUIRE(rect.height() == 4);
-		REQUIRE(rect.mHorizontalAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.mVerticalAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(rect.mHAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(rect.mVAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 	SECTION("(x, y, width, height) constructor") {
 		sfz::Rectangle<int> rect{1, 2, 3, 4};
@@ -59,8 +59,8 @@ TEST_CASE("Constructors", "[sfz::Rectangle]")
 		REQUIRE(rect.y() == 2);
 		REQUIRE(rect.width() == 3);
 		REQUIRE(rect.height() == 4);
-		REQUIRE(rect.mHorizontalAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
-		REQUIRE(rect.mVerticalAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
+		REQUIRE(rect.mHAlign == sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN);
+		REQUIRE(rect.mVAlign == sfz::Rectangle<int>::s_DEFAULT_VERTICAL_ALIGN);
 	}
 }
 
@@ -218,13 +218,13 @@ TEST_CASE("Setters", "[sfz::Rectangle]")
 
 		rect.changeHorizontalAlign(sfz::HorizontalAlign::LEFT);
 		REQUIRE(rect.x() == -1);
-		REQUIRE(rect.mHorizontalAlign == sfz::HorizontalAlign::LEFT);
+		REQUIRE(rect.mHAlign == sfz::HorizontalAlign::LEFT);
 		rect.changeHorizontalAlign(sfz::HorizontalAlign::RIGHT);
 		REQUIRE(rect.x() == 1);
-		REQUIRE(rect.mHorizontalAlign == sfz::HorizontalAlign::RIGHT);
+		REQUIRE(rect.mHAlign == sfz::HorizontalAlign::RIGHT);
 		rect.changeHorizontalAlign(sfz::HorizontalAlign::CENTER);
 		REQUIRE(rect.x() == 0);
-		REQUIRE(rect.mHorizontalAlign == sfz::HorizontalAlign::CENTER);
+		REQUIRE(rect.mHAlign == sfz::HorizontalAlign::CENTER);
 	}
 	SECTION("changeVerticalAlign()") {
 		REQUIRE(sfz::Rectangle<int>::s_DEFAULT_HORIZONTAL_ALIGN == sfz::HorizontalAlign::CENTER);
@@ -232,13 +232,13 @@ TEST_CASE("Setters", "[sfz::Rectangle]")
 
 		rect.changeVerticalAlign(sfz::VerticalAlign::TOP);
 		REQUIRE(rect.y() == 1);
-		REQUIRE(rect.mVerticalAlign == sfz::VerticalAlign::TOP);
+		REQUIRE(rect.mVAlign == sfz::VerticalAlign::TOP);
 		rect.changeVerticalAlign(sfz::VerticalAlign::BOTTOM);
 		REQUIRE(rect.y() == -1);
-		REQUIRE(rect.mVerticalAlign == sfz::VerticalAlign::BOTTOM);
+		REQUIRE(rect.mVAlign == sfz::VerticalAlign::BOTTOM);
 		rect.changeVerticalAlign(sfz::VerticalAlign::MIDDLE);
 		REQUIRE(rect.y() == 0);
-		REQUIRE(rect.mVerticalAlign == sfz::VerticalAlign::MIDDLE);
+		REQUIRE(rect.mVAlign == sfz::VerticalAlign::MIDDLE);
 	}
 }
 


### PR DESCRIPTION
Since the members are public we can assume they will be directly accessed often. Having long names for these makes them a pain to use.
